### PR TITLE
Fixes Edit JSON and Edit SQL Modes

### DIFF
--- a/client/components/dashboard/dashboard-service.js
+++ b/client/components/dashboard/dashboard-service.js
@@ -286,8 +286,11 @@ DashboardService.prototype.customizeSql = function(widget) {
   }
 
   widget.state().datasource.status = ResultsDataStatus.NODATA;
-  widget.model.datasource.query = this.queryBuilderService_.getSql(
-      widget.model.datasource.config);
+    widget.model.datasource.query = this.queryBuilderService_.getSql(
+        widget.model.datasource.config,
+        this.current.model.project_id,
+        this.current.model.dataset_name || this.DEFAULT_DATASET_NAME,
+        this.current.model.table_name || this.DEFAULT_TABLE_NAME);
   widget.model.datasource.custom_query = true;
 };
 

--- a/client/components/widget/query/query-editor-controller.js
+++ b/client/components/widget/query/query-editor-controller.js
@@ -135,7 +135,11 @@ explorer.components.widget.query.QueryEditorCtrl = function($scope, $filter,
 
   $scope.$watch(
       angular.bind(this, function() {
-        return dashboardService.selectedWidget;
+        if (dashboardService.selectedWidget) {
+          return dashboardService.selectedWidget.model;
+        } else {
+          return null;
+        }
       }),
       angular.bind(this, function() {
         if (dashboardService.selectedWidget) {

--- a/client/components/widget/query/widget-editor-directive.html
+++ b/client/components/widget/query/widget-editor-directive.html
@@ -77,7 +77,7 @@
     <div ng-switch-default class="perfkit-footer-toolbar">
       <button type="button" class="btn btn-default"
               ng-show="footerCtrl.dashboard.selectedWidget"
-              ng-click="openWidgetJsonEditor()">
+              ng-click="footerCtrl.openWidgetJsonEditor()">
         Edit Widget JSON
       </button>
       <button type="button" class="btn btn-default"


### PR DESCRIPTION
Fixes for the following issues:
- Edit JSON button does not open the footer; View SQL needs to be used to open the footer, then the user can transition to JSON mode.
- After editing JSON, changes to the Query Builder panel will no longer apply to the selected widget.  The user needs to select another widget, then re-select the original for the builder to bind changes properly.
- When transitioning to Custom SQL mode, the dataset/table are set to 'undefined'.  They are not impacted by the Dashboard or Widget-level settings for project, dataset or table.
