### PR TITLE
Update /static handler to point at app-specific folder.

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -24,6 +24,15 @@ handlers:
   static_dir: client
   login: required
 
+# Use version number as part of static file URLs so that long expiration times
+# will not affect changes in new deployments.  This is accomplished by the
+# handler providing a template variable static_dir, see
+# _RequestHandler.RenderHtml in perfkit.explorer.handlers.base.
+- url: /_static/.+?/(.*)
+  static_files: client/\1
+  upload: client/(.*)
+  secure: always
+
 # Provides interactive console for debugging purposes in production.
 # This is equivalent to /_ah/admin in dev_app_server.
 - url: /_ah/dev_console(/.*)?

--- a/server/perfkit/explorer/handlers/templates/dashboard-admin.html
+++ b/server/perfkit/explorer/handlers/templates/dashboard-admin.html
@@ -33,9 +33,10 @@
   </script>
 
   <!-- Perfkit -->
-  <script src="/static/perfkit_scripts.js"></script>
+  <script src="[[static_dir]]/perfkit_scripts.js"></script>
+
   <link href="//netdna.bootstrapcdn.com/bootstrap/3.1.0/css/bootstrap.min.css" rel="stylesheet">
-  <link type="text/css" rel="stylesheet" href="/static/perfkit_styles.css" />
+  <link type="text/css" rel="stylesheet" href="[[static_dir]]/perfkit_styles.css" />
 </head>
 <body>
 

--- a/server/perfkit/explorer/handlers/templates/explorer.html
+++ b/server/perfkit/explorer/handlers/templates/explorer.html
@@ -48,8 +48,8 @@
   </script>
 
   <!-- Perfkit -->
-  <script src="/static/perfkit_scripts.js"></script>
-  <link type="text/css" rel="stylesheet" href="/static/perfkit_styles.css" />
+  <script src="[[static_dir]]/perfkit_scripts.js"></script>
+  <link type="text/css" rel="stylesheet" href="[[static_dir]]/perfkit_styles.css" />
 </head>
 <body>
 


### PR DESCRIPTION
This resolves an issue where scripts were being cached after new version deployment.
