### PR TITLE
Add grunt compiler and html2js templates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@ __pycache__/
 # Deployment folder.
 deploy/
 
+# Node Packages folder.
+node_modules/
+
 # C extensions
 *.so
 

--- a/README.md
+++ b/README.md
@@ -56,10 +56,24 @@ Set up your workstation
              compile.sh
              app.yaml
 
-10. Change to the PerfKitExplorer folder and download the Closure Tools, which are included as
-    a submodule in the project:
+10. Change to the PerfKitExplorer folder and download the Closure Tools, which
+    are included as a submodule in the project:
 
          git submodule update --init
+
+11. Install NodeJS.
+
+         sudo apt-get install nodejs
+
+12. Install the Node Package Manager (NPM) packages for Gulp and dependencies.
+
+         npm install --global gulp
+         npm install --save-dev gulp
+         npm install --global gulp-ng-html2js
+         npm install --global gulp-minify-html
+         npm install --global gulp-concat
+         npm install --global gulp-uglify
+
 
 Create the App Engine project
 =============================
@@ -95,7 +109,7 @@ Create the BigQuery repository
 6. Add the service account from your App Engine project as an authorized use of your BigQuery project.
 
 Compile and Deploy PerfKit Explorer
-
+===================================
 1. Navigate to the PerfKitExplorer directory:
 
          cd ~/projects/PerfKitExplorer

--- a/README.md
+++ b/README.md
@@ -67,12 +67,7 @@ Set up your workstation
 
 12. Install the Node Package Manager (NPM) packages for Gulp and dependencies.
 
-         npm install --global gulp
-         npm install --save-dev gulp
-         npm install --global gulp-ng-html2js
-         npm install --global gulp-minify-html
-         npm install --global gulp-concat
-         npm install --global gulp-uglify
+         npm install
 
 
 Create the App Engine project

--- a/client/app.js
+++ b/client/app.js
@@ -77,7 +77,8 @@ goog.scope(function() {
 var explorer = p3rf.perfkit.explorer;
 var requiredModules = [
   'ui.codemirror', 'ui.bootstrap', 'ui.grid', 'ui.grid.autoResize',
-  'ui.grid.resizeColumns', 'ui.grid.selection'];
+  'ui.grid.resizeColumns', 'ui.grid.selection',
+  'p3rf.perfkit.explorer.templates'];
 
 var useMockData = (
     explorer.mocks.mocks.isMockParamTrue());

--- a/compile.cmd
+++ b/compile.cmd
@@ -27,7 +27,7 @@ xcopy .\third_party\py\*.* .\deploy\server\third_party\ /S >> last_compile.log
 
 ECHO "* Compile client/*.js (not tests) with Closure to deploy/client/perfkit_scripts.js."
 ECHO "* Compile client/*.html with Html2Js to deploy/client/perfkit_templates.js."
-gulp
+node_modules/.bin/gulp
 
 SET CSS_TEMPFILE=deploy\perfkit_styles_raw.css
 ECHO ** Combine the client/*.css stylesheets into a single file.

--- a/compile.cmd
+++ b/compile.cmd
@@ -25,21 +25,9 @@ xcopy .\server\*.html .\deploy\server\ /S >> last_compile.log
 ECHO ** Copy third_party/py files to deploy/server/third_party
 xcopy .\third_party\py\*.* .\deploy\server\third_party\ /S >> last_compile.log
 
-ECHO ** Copy client/*.html template files to deploy/client.
-xcopy .\client\*.html .\deploy\client\ /S >> last_compile.log
-
-ECHO ** Compile client/*.js files to deploy/client/perfkit_scripts.js.
-python %closurelib%/closure/bin/build/closurebuilder.py ^
- --root=%closurelib%/ ^
- --root=client/ ^
- --namespace="p3rf.perfkit.explorer.application.module" ^
- --output_mode=compiled ^
- --compiler_jar=bin/closure-compiler.jar ^
- --compiler_flags="--angular_pass" ^
- --compiler_flags="--compilation_level=WHITESPACE_ONLY" ^
- --compiler_flags="--language_in=ECMASCRIPT5" ^
- --compiler_flags="--formatting=PRETTY_PRINT" ^
- --output_file=deploy/client/perfkit_scripts.js >> last_compile.log
+ECHO "* Compile client/*.js (not tests) with Closure to deploy/client/perfkit_scripts.js."
+ECHO "* Compile client/*.html with Html2Js to deploy/client/perfkit_templates.js."
+gulp
 
 SET CSS_TEMPFILE=deploy\perfkit_styles_raw.css
 ECHO ** Combine the client/*.css stylesheets into a single file.

--- a/compile.sh
+++ b/compile.sh
@@ -21,31 +21,14 @@ cd third_party/py
 find . -type f -name '*.py' | cpio -p -a -m -d --quiet ../../deploy/server/third_party/
 cd ../..
 
-echo "* Copy client/*.html and json template files to deploy/client."
-find client -name '*.html' | cpio -pamd --quiet deploy/
-find client -name '*.json' | cpio -pamd --quiet deploy/
-
 echo "* Copy third_party/js/*.* files to deploy/server/third_party."
 cd third_party/js
 find . -type f -name '*.*' | cpio -p -a -m -d --quiet ../../deploy/client/third_party/
 cd ../..
 
-echo "** Compiling files."
-echo "* Compile client/*.js (not tests) to deploy/client/perfkit_scripts.js."
-find client lib/closure-library/closure/goog \
-    -name '*_test.js' -prune \
-    -o -name 'karma.conf.js' -prune \
-    -o -name '*.js' -print | xargs \
-  java -jar bin/closure-compiler.jar \
-      --angular_pass \
-      --compilation_level=WHITESPACE_ONLY \
-      --language_in=ECMASCRIPT5 \
-      --formatting=PRETTY_PRINT \
-      --manage_closure_dependencies \
-      --only_closure_dependencies \
-      --process_closure_primitives true \
-      --closure_entry_point p3rf.perfkit.explorer.application.module \
-      --js_output_file=deploy/client/perfkit_scripts.js
+echo "* Compile client/*.js (not tests) with Closure to deploy/client/perfkit_scripts.js."
+echo "* Compile client/*.html with Html2Js to deploy/client/perfkit_templates.js."
+gulp
 
 echo "* Compile client/*.css stylesheets to deploy/client/perfkit_styles.css."
 find client -name '*.css'| xargs \

--- a/compile.sh
+++ b/compile.sh
@@ -28,7 +28,7 @@ cd ../..
 
 echo "* Compile client/*.js (not tests) with Closure to deploy/client/perfkit_scripts.js."
 echo "* Compile client/*.html with Html2Js to deploy/client/perfkit_templates.js."
-gulp
+$(npm bin)/gulp
 
 echo "* Compile client/*.css stylesheets to deploy/client/perfkit_styles.css."
 find client -name '*.css'| xargs \

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,0 +1,47 @@
+var gulp = require('gulp');
+
+var closureCompiler = require('gulp-closure-compiler');
+var minifyHtml = require('gulp-minify-html');
+var ngHtml2Js = require('gulp-ng-html2js');
+var concat = require('gulp-concat');
+var uglify = require('gulp-uglify');
+
+gulp.task('default', function() {
+
+  gulp.src([
+      'client/**/*.js', '!client/**/*_test.js', '!client/karma.conf.js',
+      'lib/closure-library/closure/goog/**/*.js',
+      '!lib/closure-library/closure/goog/**/*_test.js'])
+    .pipe(closureCompiler({
+      compilerPath: 'bin/closure-compiler.jar',
+      fileName: 'client/perfkit_scripts.js',
+      compilerFlags: {
+        angular_pass: true,
+        compilation_level: 'WHITESPACE_ONLY',
+        language_in: 'ECMASCRIPT5',
+        manage_closure_dependencies: true,
+        only_closure_dependencies: true,
+        process_closure_primitives: true,
+        closure_entry_point: 'p3rf.perfkit.explorer.application.module'
+      }
+    }))
+    .pipe(gulp.dest('deploy'));
+
+  gulp.src('client/**/*.html')
+    .pipe(minifyHtml({
+        empty: true,
+        spare: true,
+        quotes: true
+    }))
+    .pipe(ngHtml2Js({
+        moduleName: 'p3rf.perfkit.explorer.templates',
+        prefix: '/static/'
+    }))
+    .pipe(concat('perfkit_templates.js'))
+    .pipe(uglify())
+    .pipe(gulp.dest('deploy/client'));
+
+  gulp.src('client/**/*.json')
+    .pipe(gulp.dest('deploy/client'));
+
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "perfkit-explorer-deps",
+  "version": "1.0.0",
+  "description": "NPM dev/test dependencies for PerfKit Explorer",
+  "author": "Joe Allan Muharsky <jmuharsky@gmail.com>",
+  "dependencies": {
+    "gulp": "3.8.x"
+  },
+  "devDependencies": {
+    "gulp": "3.8.x",
+    "gulp-closure-compiler": "0.2.x",
+    "gulp-ng-html2js": "0.1.x",
+    "gulp-minify-html": "0.1.x",
+    "gulp-concat": "2.5.x",
+    "gulp-uglify": "1.1.x"
+  },
+  "preferGlobal": true,
+  "private": true,
+  "license": "Apache2"
+}

--- a/server/perfkit/explorer/handlers/templates/dashboard-admin.html
+++ b/server/perfkit/explorer/handlers/templates/dashboard-admin.html
@@ -33,6 +33,7 @@
   </script>
 
   <!-- Perfkit -->
+  <script src="[[static_dir]]/perfkit_templates.js"></script>
   <script src="[[static_dir]]/perfkit_scripts.js"></script>
 
   <link href="//netdna.bootstrapcdn.com/bootstrap/3.1.0/css/bootstrap.min.css" rel="stylesheet">

--- a/server/perfkit/explorer/handlers/templates/explorer.html
+++ b/server/perfkit/explorer/handlers/templates/explorer.html
@@ -48,6 +48,7 @@
   </script>
 
   <!-- Perfkit -->
+  <script src="[[static_dir]]/perfkit_templates.js"></script>
   <script src="[[static_dir]]/perfkit_scripts.js"></script>
   <link type="text/css" rel="stylesheet" href="[[static_dir]]/perfkit_styles.css" />
 </head>


### PR DESCRIPTION
This compiles the .html templates into /client/perfkit_template.js, which will prevent caching in the future and improve performance.