### PR TITLE
Sanity checks and tweaks to compile environment

### DIFF
--- a/compile.sh
+++ b/compile.sh
@@ -1,6 +1,19 @@
 #!/bin/bash
 
+# Exit on errors.
+set -e
+
 echo "** Compilation initializing."
+
+Die () {
+  echo >&2 Error: "$@"
+  exit 1
+}
+
+# Sanity check that we're in the right directory.
+[ -f gulpfile.js -a -d server/perfkit/explorer ] || Die \
+  "Run this as ./compile.sh in the PerfKitExplorer directory."
+
 echo "* Clean out the existing deployment content."
 rm -r -f deploy
 
@@ -11,6 +24,6 @@ java -jar bin/closure-stylesheets.jar \
   --output-file deploy/client/perfkit_styles.css \
   --allow-unrecognized-functions \
   --allow-unrecognized-properties \
-  out/perfkit_styles.css
+  build/perfkit_styles.css
 
 echo "** Compilation complete."

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,10 +1,17 @@
 var gulp = require('gulp');
 
-var closureCompiler = require('gulp-closure-compiler');
-var minifyHtml = require('gulp-minify-html');
-var ngHtml2Js = require('gulp-ng-html2js');
-var concat = require('gulp-concat');
-var uglify = require('gulp-uglify');
+try {
+  var closureCompiler = require('gulp-closure-compiler');
+  var minifyHtml = require('gulp-minify-html');
+  var ngHtml2Js = require('gulp-ng-html2js');
+  var concat = require('gulp-concat');
+  var uglify = require('gulp-uglify');
+  var flatten = require('gulp-flatten');
+} catch (e) {
+  console.log(e.stack);
+  console.error('Required module not found. Please re-run "npm install".');
+  process.exit(1);
+}
 
 
 var jsSourceFiles = [
@@ -36,7 +43,7 @@ gulp.task('common', function() {
 
   gulp.src('client/**/*.css')
     .pipe(concat('perfkit_styles.css'))
-    .pipe(gulp.dest('out'));
+    .pipe(gulp.dest('build'));
 });
 
 
@@ -77,7 +84,7 @@ gulp.task('prod', ['common'], function() {
   gulp.src(jsSourceFiles)
     .pipe(closureCompiler({
       compilerPath: 'bin/closure-compiler.jar',
-      fileName: 'client/perfkit_scripts.js',
+      fileName: 'build/perfkit_scripts.js',
       compilerFlags: {
         angular_pass: true,
         compilation_level: 'WHITESPACE_ONLY',
@@ -88,7 +95,8 @@ gulp.task('prod', ['common'], function() {
         closure_entry_point: 'p3rf.perfkit.explorer.application.module'
       }
     }))
-    .pipe(gulp.dest('deploy'));
+    .pipe(flatten())
+    .pipe(gulp.dest('deploy/client'));
 
   gulp.src('server/**/*.html')
     .pipe(minifyHtml({

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "gulp-ng-html2js": "0.1.x",
     "gulp-minify-html": "0.1.x",
     "gulp-concat": "2.5.x",
+    "gulp-flatten": "0.0.x",
     "gulp-uglify": "1.1.x"
   },
   "preferGlobal": true,


### PR DESCRIPTION
* fix compile.sh to exit on errors instead of continuing after failed steps.

* add sanity check to verify we're in the right directory, especially
  considering that the first thing it does is a "rm -rf".

* use build/ directory for generated build artifacts consistently:

  * Write compiled JS code to build/perfkit_scripts.js instead of client/.
    This avoids the "Circular dependency detected" error it otherwise gets when recompiling,
    and avoids having git complain about an untracked file. Uses 'gulp-flatten' module.

  * Write CSS to build/perfkit_styles.css instead of out/.

* Add a try/catch around toplevel imports so that there's a friendlier error
  message when a required module is missing. See example: https://gist.github.com/klausw/573418af6061dc83fecd