### PR TITLE
Fix gviz test and improve error messaging.

### DIFF
--- a/client/components/alert/error_service.js
+++ b/client/components/alert/error_service.js
@@ -31,31 +31,35 @@ var ErrorTypes = components.error.ErrorTypes;
 
 
 /**
- * @param {!angular.$rootScope} $rootScope Provides access to the root scope.
- * @param {!angular.$filter} $filter Angular filter service.
+ * @param {!angular.RootScope} $rootScope Provides access to the root scope.
+ * @param {!angular.Filter} $filter Angular filter service.
+ * @param {!angular.Window} $window Angular window service.
  * @ngInject
  * @constructor
  */
-components.error.ErrorService = function($rootScope, $filter) {
+components.error.ErrorService = function($rootScope, $filter, $window) {
   /** @type {angular.Filter} */
   this.filter_ = $filter;
 
+  /** @type {angular.Window} */
+  this.window_ = window;
+
+  /** @type {angular.RootScope} */
   this.rootScope_ = $rootScope;
 
-  /**
-   * @export @type {Array.<ErrorModel>}
-   */
+  /** @export {!Array.<ErrorModel>} */
   this.errors = [];
 
-  /**
-   * @export @type {Array.<!string>}
-   */
+  /** @export {!Array.<!string>} */
   this.errorTypes = ErrorTypes.All;
+
+  /** @export {!boolean} */
+  this.logToConsole = true;
 
   /**
    * The worst error severity to show.  For example, WARNING would show both
    * WARNING and DANGER alerts.
-   * @export @type {!string}
+   * @export {!ErrorTypes}
    */
   this.MAX_ERROR_SEVERITY = ErrorTypes.WARNING;
 };
@@ -94,6 +98,11 @@ ErrorService.prototype.addError = function(errorType, text, opt_errorId) {
   }
   var error = new ErrorModel(errorType, text, opt_errorId);
   this.errors.push(error);
+
+  if (this.logToConsole === true) {
+    this.window_.console.log(text);
+  }
+
   return error;
 };
 

--- a/client/components/dashboard/dashboard-service.js
+++ b/client/components/dashboard/dashboard-service.js
@@ -20,6 +20,8 @@
 
 goog.provide('p3rf.perfkit.explorer.components.dashboard.DashboardService');
 
+goog.require('p3rf.perfkit.explorer.components.error.ErrorService');
+goog.require('p3rf.perfkit.explorer.components.error.ErrorTypes');
 goog.require('p3rf.perfkit.explorer.components.config.ConfigService');
 goog.require('p3rf.perfkit.explorer.components.container.ContainerWidgetConfig');
 goog.require('p3rf.perfkit.explorer.components.dashboard.DashboardConfig');
@@ -45,6 +47,8 @@ var ContainerWidgetConfig = explorer.components.container.ContainerWidgetConfig;
 var DashboardConfig = explorer.components.dashboard.DashboardConfig;
 var DashboardParam = explorer.components.dashboard.DashboardParam;
 var DashboardDataService = explorer.components.dashboard.DashboardDataService;
+var ErrorService = explorer.components.error.ErrorService;
+var ErrorTypes = explorer.components.error.ErrorTypes;
 var QueryBuilderService = (
     explorer.models.perfkit_simple_builder.QueryBuilderService);
 var QueryTablePartitioning = (
@@ -59,6 +63,7 @@ var WidgetType = explorer.models.WidgetType;
  * See module docstring for more information about purpose and usage.
  *
  * @param {!ArrayUtilService} arrayUtilService
+ * @param {!ErrorService} errorService
  * @param {!WidgetFactoryService} widgetFactoryService
  * @param {!DashboardDataService} dashboardDataService
  * @param {!QueryBuilderService} queryBuilderService
@@ -72,9 +77,9 @@ var WidgetType = explorer.models.WidgetType;
  * @ngInject
  */
 explorer.components.dashboard.DashboardService = function(arrayUtilService,
-    widgetFactoryService, dashboardDataService, queryBuilderService,
-    dashboardVersionService, configService, $filter, $location, $rootScope,
-    $timeout, $window) {
+    errorService, widgetFactoryService, dashboardDataService,
+    queryBuilderService,  dashboardVersionService, configService, $filter,
+    $location, $rootScope, $timeout, $window) {
   /** @private {!angular.Filter} */
   this.filter_ = $filter;
 
@@ -89,6 +94,9 @@ explorer.components.dashboard.DashboardService = function(arrayUtilService,
 
   /** @private {!ArrayUtilService} */
   this.arrayUtilService_ = arrayUtilService;
+
+  /** @private {!ArrayUtilService} */
+  this.errorService_ = errorService;
 
   /** @private {!WidgetFactoryService} */
   this.widgetFactoryService_ = widgetFactoryService;
@@ -350,19 +358,35 @@ DashboardService.prototype.rewriteQuery = function(widget, replaceParams) {
   var project_name = this.arrayUtilService_.getFirst([
       widgetConfig.results.project_id,
       this.current.model.project_id,
-      this.config.default_project], true);
+      this.config.default_project], false);
+  if (project_name === null) {
+    this.errorService_.addError(ErrorTypes.DANGER, 'Project name not found.');
+  }
+
   var dataset_name = this.arrayUtilService_.getFirst([
       widgetConfig.results.dataset_name,
       this.current.model.dataset_name,
-      this.config.default_dataset], true);
+      this.config.default_dataset], false);
+  if (project_name === null) {
+    this.errorService_.addError(ErrorTypes.DANGER, 'Dataset name not found.');
+  }
+
   var table_name = this.arrayUtilService_.getFirst([
       widgetConfig.results.table_name,
       this.current.model.table_name,
-      this.config.default_table], true);
+      this.config.default_table], false);
+  if (project_name === null) {
+    this.errorService_.addError(ErrorTypes.DANGER, 'Table name not found.');
+  }
+
   var table_partition = this.arrayUtilService_.getFirst([
       widgetConfig.results.table_partition,
       this.current.model.table_partition,
-      this.DEFAULT_TABLE_PARTITION], true);
+      this.DEFAULT_TABLE_PARTITION], false);
+  if (project_name === null) {
+    this.errorService_.addError(ErrorTypes.DANGER,
+                                'Table partition not found.');
+  }
 
   this.initializeParams_();
   var params = replaceParams ? this.params : null;

--- a/client/components/widget/data_viz/gviz/gviz-directive_test.js
+++ b/client/components/widget/data_viz/gviz/gviz-directive_test.js
@@ -103,15 +103,26 @@ describe('gvizDirective', function() {
   }));
 
   beforeEach(inject(function($compile, $rootScope, $timeout, GvizChartWrapper,
-      gvizEvents, _GvizDataTable_, dataViewService, _widgetFactoryService_) {
+      gvizEvents, _GvizDataTable_, dataViewService, _configService_,
+      _widgetFactoryService_) {
         compile = $compile;
         rootScope = $rootScope;
         timeout = $timeout;
+        configService = _configService_;
         widgetFactoryService = _widgetFactoryService_;
         chartWrapperMock = GvizChartWrapper.prototype;
         gvizEventsMock = gvizEvents;
         GvizDataTable = _GvizDataTable_;
         dataViewServiceMock = dataViewService;
+
+        // Setup global config.
+        configService.populate({
+          'default_project': 'TEST_PROJECT',
+          'default_dataset': 'TEST_DATASET',
+          'default_table': 'TEST_TABLE',
+          'analytics_key': 'TEST_ANALYTICS_KEY',
+          'cache_duration': 30
+        });
 
         // Return 10 rows by default
         GvizDataTable.prototype.getNumberOfRows.and.returnValue(10);


### PR DESCRIPTION
* Fix issue with gviz tests failing due to missing global config for project, dataset, table, etc.
* Improve error messaging when project, dataset, table, etc. values cannot be found in the widget, dashboard or global scopes.
* Add an option to the error service to log to console, and default to true.