### PR TITLE
Changed @expose to @export

### DIFF
--- a/client/components/container/container-model.js
+++ b/client/components/container/container-model.js
@@ -50,25 +50,25 @@ p3rf.perfkit.explorer.components.container.
 ContainerModel = function() {
   /**
    * @type {Flow}
-   * @expose
+   * @export
    */
   this.flow = Flow.ROW;
 
   /**
    * @type {number}
-   * @expose
+   * @export
    */
   this.columns = 1;
 
   /**
    * @type {number}
-   * @expose
+   * @export
    */
   this.height = 250;
 
   /**
    * @type {Array.<WidgetConfig>}
-   * @expose
+   * @export
    */
   this.children = [];
 };
@@ -88,7 +88,7 @@ ContainerWidgetModel = function() {
 
   /**
    * @type {ContainerModel}
-   * @expose
+   * @export
    */
   this.container = new ContainerModel();
 };
@@ -118,7 +118,7 @@ ContainerWidgetConfig = function(
    * ContainerWidgetConfig object that contains it.
    *
    * @type {!(Object|ContainerWidgetModel)}
-   * @expose
+   * @export
    */
   this.model = opt_model || new ContainerWidgetModel();
 
@@ -137,7 +137,7 @@ ContainerWidgetConfig = function(
    * dependency error.
    *
    * @return {WidgetState}
-   * @expose
+   * @export
    */
   this.state = function() {
     return widgetFactoryService.statesById[this.model.id];

--- a/client/components/dashboard/dashboard-model.js
+++ b/client/components/dashboard/dashboard-model.js
@@ -61,7 +61,7 @@ explorer.components.dashboard.DashboardModel = function() {
 
   /**
    * @type {string}
-   * @expose
+   * @export
    */
   this.title = 'Untitled Dashboard';
 
@@ -161,7 +161,7 @@ explorer.components.dashboard.DashboardConfig = function(opt_model) {
    * DashboardConfig object that contains it.
    *
    * @type {!(Object|DashboardModel)}
-   * @expose
+   * @export
    */
   this.model = opt_model || new DashboardModel();
 };

--- a/client/components/dashboard_admin_page/dashboard-admin-page-model.js
+++ b/client/components/dashboard_admin_page/dashboard-admin-page-model.js
@@ -29,19 +29,19 @@ var explorer = p3rf.perfkit.explorer;
 explorer.components.dashboard_admin_page.DashboardAdminPageModel = function() {
   /**
    * @type {bool}
-   * @expose
+   * @export
    */
   this.filter_owner = false;
 
   /**
    * @type {?string}
-   * @expose
+   * @export
    */
   this.owner = null;
 
   /**
    * @type {?bool}
-   * @expose
+   * @export
    */
   this.mine = null;
 };

--- a/client/components/widget/query/query-editor-controller.js
+++ b/client/components/widget/query/query-editor-controller.js
@@ -432,7 +432,7 @@ QueryEditorCtrl.prototype.addMeasureColumn = function() {
 
 /**
  * Adds a new option to the metadata list.
- * @expose
+ * @export
  */
 QueryEditorCtrl.prototype.addMetadataColumn = function() {
   this.datasource.config.results.labels.push(new LabelResult());

--- a/client/components/widget/widget-factory-service.js
+++ b/client/components/widget/widget-factory-service.js
@@ -67,7 +67,7 @@ explorer.components.widget.WidgetFactoryService = function(
    * Hash table of widgets.
    *
    * @type {!Object.<(ContainerWidgetConfig|WidgetConfig)>}
-   * @expose
+   * @export
    */
   this.widgetsById = {};
 
@@ -75,7 +75,7 @@ explorer.components.widget.WidgetFactoryService = function(
    * Hash table of widgets states.
    *
    * @type {!Object.<WidgetState>}
-   * @expose
+   * @export
    */
   this.statesById = {};
 

--- a/client/models/widget_model.js
+++ b/client/models/widget_model.js
@@ -43,7 +43,7 @@ var WidgetType = explorer.models.WidgetType;
 explorer.models.WidgetState = function() {
   /**
    * @type {boolean}
-   * @expose
+   * @export
    */
   this.selected = false;
 
@@ -51,7 +51,7 @@ explorer.models.WidgetState = function() {
    * TODO: Change type to ContainerWidgetConfig when we figure
    * out how to solve the circular dependency.
    * @type {Object}
-   * @expose
+   * @export
    */
   this.parent = null;
 };
@@ -63,13 +63,13 @@ var WidgetState = explorer.models.WidgetState;
 explorer.models.LayoutModel = function() {
   /**
    * @type {number}
-   * @expose
+   * @export
    */
   this.columnspan = 1;
 
   /**
    * @type {?string}
-   * @expose
+   * @export
    */
   this.cssClasses = null;
 };
@@ -81,31 +81,31 @@ var LayoutModel = explorer.models.LayoutModel;
 explorer.models.WidgetModel = function() {
   /**
    * @type {?string}
-   * @expose
+   * @export
    */
   this.id = null;
 
   /**
    * @type {string}
-   * @expose
+   * @export
    */
   this.title = '';
 
   /**
    * @type {string}
-   * @expose
+   * @export
    */
   this.url = '';
 
   /**
    * @type {?string}
-   * @expose
+   * @export
    */
   this.type = null;
 
   /**
    * @type {!LayoutModel}
-   * @expose
+   * @export
    */
   this.layout = new LayoutModel();
 };
@@ -129,7 +129,7 @@ explorer.models.WidgetConfig = function(widgetFactoryService, opt_model) {
    * WidgetConfig object that contains it.
    *
    * @type {!(Object|WidgetModel)}
-   * @expose
+   * @export
    */
   this.model = opt_model || new WidgetModel();
 
@@ -148,7 +148,7 @@ explorer.models.WidgetConfig = function(widgetFactoryService, opt_model) {
    * dependency error.
    *
    * @return {WidgetState}
-   * @expose
+   * @export
    */
   this.state = function() {
     return widgetFactoryService.statesById[this.model.id];


### PR DESCRIPTION
@expose is a deprecated means in the Closure compiler for preventing a symbol from being obfuscated/minified. This allows html templates to correctly reference property and method names.  @export is the preferred decorator for this behavior.