### PR TITLE
Fix popupbox

### DIFF
--- a/client/components/popupbox/popupbox-directive.js
+++ b/client/components/popupbox/popupbox-directive.js
@@ -45,6 +45,8 @@ goog.require('goog.style');
 goog.scope(function() {
 var explorer = p3rf.perfkit.explorer;
 
+const DEFAULT_TEMPLATE_URL = (
+    '/static/components/popupbox/popupbox-directive.html');
 
 /**
  * The Popupbox directive provides for a templated popup region that appears
@@ -63,9 +65,8 @@ explorer.components.popupbox.PopupboxDirective = function($timeout) {
   return {
     restrict: 'A',
     transclude: false,
-    templateUrl: function(scope, element, attrs) {
-      return scope.popupboxTemplateUrl ||
-          '/static/components/popupbox/popupbox-directive.html';
+    templateUrl: function(element, attrs) {
+      return attrs.popupboxTemplateUrl || DEFAULT_TEMPLATE_URL;
     },
     scope: {
       /**
@@ -77,9 +78,7 @@ explorer.components.popupbox.PopupboxDirective = function($timeout) {
       /**
        * The model element that represents the "selected" value for the popup.
        */
-      popupboxModel: '=',
-
-      popupboxTemplateUrl: '&'
+      popupboxModel: '='
     },
     link: function(scope, element, attrs) {
       var input = element;

--- a/client/components/popupbox/popupbox-directive.js
+++ b/client/components/popupbox/popupbox-directive.js
@@ -45,7 +45,7 @@ goog.require('goog.style');
 goog.scope(function() {
 const explorer = p3rf.perfkit.explorer;
 
-var DEFAULT_TEMPLATE_URL = (
+const DEFAULT_TEMPLATE_URL = (
     '/static/components/popupbox/popupbox-directive.html');
 
 /**

--- a/client/components/popupbox/popupbox-directive.js
+++ b/client/components/popupbox/popupbox-directive.js
@@ -45,7 +45,7 @@ goog.require('goog.style');
 goog.scope(function() {
 var explorer = p3rf.perfkit.explorer;
 
-const DEFAULT_TEMPLATE_URL = (
+var DEFAULT_TEMPLATE_URL = (
     '/static/components/popupbox/popupbox-directive.html');
 
 /**

--- a/client/components/popupbox/popupbox-directive_test.js
+++ b/client/components/popupbox/popupbox-directive_test.js
@@ -18,7 +18,7 @@
  * @author joemu@google.com (Joe Allan Muharsky)
  */
 
-describe('popupbox', function() {
+fdescribe('popupbox', function() {
   'use strict';
 
   var scope, element, $compile, $timeout, $httpBackend;

--- a/client/components/popupbox/popupbox-directive_test.js
+++ b/client/components/popupbox/popupbox-directive_test.js
@@ -18,7 +18,7 @@
  * @author joemu@google.com (Joe Allan Muharsky)
  */
 
-fdescribe('popupbox', function() {
+describe('popupbox', function() {
   'use strict';
 
   var scope, element, $compile, $timeout, $httpBackend;

--- a/client/components/widget/query/builder/query-builder-column-config-directive.html
+++ b/client/components/widget/query/builder/query-builder-column-config-directive.html
@@ -17,7 +17,7 @@
     <div class="sidebar-item-value">
       <input class="form-control widget-columns-date-group"
          popupbox
-         popupbox-template-url="queryEditorSvc.picklist_template_url"
+         popupbox-template-url="/static/components/widget/query/picklist-template.html"
          popupbox-data="queryEditorSvc.date_groupings"
          popupbox-model="ngModel.datasource.config.results.date_group"
          ng-model="ngModel.datasource.config.results.date_group">

--- a/client/components/widget/query/builder/query-builder-filter-config-directive.html
+++ b/client/components/widget/query/builder/query-builder-filter-config-directive.html
@@ -1,6 +1,6 @@
 <div>
   <script type="text/ng-template" id="date_picker.template">
-    <div class="pk-popup" tabindex="-1">
+    <div class="perfkit-popup" tabindex="-1">
       <relative-datepicker
           relative-datepicker-data="popupboxModel"></relative-datepicker>
     </div>
@@ -55,8 +55,10 @@
              popupbox-template-url="date_picker.template"
              popupbox-model="ngModel.datasource.config.filters.end_date"
              ng-model="ngModel.datasource.config.filters.end_date.text">
-      <span class="glyphicon glyphicon-remove widget-filter-end-date-remove"
-            ng-click="removeEndDate()"></span>
+      <span class="widget-filter-end-date-remove input-group-addon"
+            ng-click="removeEndDate()">
+        <i class="glyphicon glyphicon-remove"></i>
+      </span>
     </div>
   </div>
 

--- a/client/components/widget/query/builder/query-builder-filter-config-directive.html
+++ b/client/components/widget/query/builder/query-builder-filter-config-directive.html
@@ -1,6 +1,6 @@
 <div>
-  <script type="text/ng-template" id="date_template.html">
-    <div class="perfkit-popup" tabindex="-1">
+  <script type="text/ng-template" id="date_picker.template">
+    <div class="pk-popup" tabindex="-1">
       <relative-datepicker
           relative-datepicker-data="popupboxModel"></relative-datepicker>
     </div>
@@ -38,7 +38,7 @@
     <div class="sidebar-item-value">
       <input class="form-control widget-filter-start-date"
              popupbox
-             popupbox-template-url="date_template.html"
+             popupbox-template-url="date_picker.template"
              popupbox-model="ngModel.datasource.config.filters.start_date"
              ng-model="ngModel.datasource.config.filters.start_date.text">
     </div>
@@ -52,7 +52,7 @@
     <div class="sidebar-item-value input-group">
       <input class="form-control widget-filter-end-date"
              popupbox
-             popupbox-template-url="date_template.html"
+             popupbox-template-url="date_picker.template"
              popupbox-model="ngModel.datasource.config.filters.end_date"
              ng-model="ngModel.datasource.config.filters.end_date.text">
       <span class="glyphicon glyphicon-remove widget-filter-end-date-remove"

--- a/client/components/widget/query/builder/query-builder-filter-config-directive_test.js
+++ b/client/components/widget/query/builder/query-builder-filter-config-directive_test.js
@@ -33,7 +33,7 @@ describe('QueryFilterDirective', function() {
   var ChartWidgetModel = explorer.models.ChartWidgetModel;
 
   const TEMPLATE_DATEPICKER = 'template/datepicker/datepicker.html';
-  const TEMPLATE_TIMEPICKER = 'template/datepicker/timepicker.html';
+  const TEMPLATE_TIMEPICKER = 'template/timepicker/timepicker.html';
 
   beforeEach(module('explorer'));
   beforeEach(module('p3rf.perfkit.explorer.templates'));


### PR DESCRIPTION
Reverts an earlier change made to popupbox to support dynamic templates.  As a directive's templateUrl resolver doesn't have access to the scope, driving the template selection from the html using dynamic values (such as goog.string functionality or relying on data/constants from services) is problematic and will require a more complicated workaround.

Also fixes a styling issue with the end date filter close button.