### PR TITLE
Add explorer state

### DIFF
--- a/client/app.js
+++ b/client/app.js
@@ -41,7 +41,9 @@ goog.require('p3rf.perfkit.explorer.components.error.ErrorService');
 goog.require('p3rf.perfkit.explorer.components.explorer.ExplorerCtrl');
 goog.require('p3rf.perfkit.explorer.components.explorer.ExplorerHeaderDirective');
 goog.require('p3rf.perfkit.explorer.components.explorer.ExplorerPageDirective');
+goog.require('p3rf.perfkit.explorer.components.explorer.ExplorerRouterConfig');
 goog.require('p3rf.perfkit.explorer.components.explorer.ExplorerService');
+goog.require('p3rf.perfkit.explorer.components.explorer.ExplorerStateService');
 goog.require('p3rf.perfkit.explorer.components.explorer.ExplorerToolbarDirective');
 goog.require('p3rf.perfkit.explorer.components.explorer.sidebar.SidebarDirective');
 goog.require('p3rf.perfkit.explorer.components.explorer.sidebar.SidebarTabsDirective');
@@ -89,7 +91,7 @@ goog.scope(function() {
 const explorer = p3rf.perfkit.explorer;
 let requiredModules = [
   'ui.codemirror', 'ui.bootstrap', 'ui.grid', 'ui.grid.autoResize',
-  'ui.grid.resizeColumns', 'ui.grid.selection', 'ngMaterial',
+  'ui.grid.resizeColumns', 'ui.grid.selection', 'ui.router', 'ngMaterial',
   'p3rf.perfkit.explorer.templates',
   explorer.mocks.application.module.name];
 
@@ -102,11 +104,13 @@ if (useMockData) {
   requiredModules.push('ngMockE2E');
 }
 
-
 /**
  * The main module for the Explorer app.
  */
 explorer.application.module = angular.module('explorer', requiredModules);
+
+explorer.application.module.config(
+    explorer.components.explorer.ExplorerRouterConfig);
 
 explorer.application.module.config(
     ['$locationProvider', function($locationProvider) {
@@ -136,6 +140,8 @@ explorer.application.module.service('arrayUtilService',
     explorer.components.util.ArrayUtilService);
 explorer.application.module.service('explorerService',
     explorer.components.explorer.ExplorerService);
+explorer.application.module.service('explorerStateService',
+    explorer.components.explorer.ExplorerStateService);
 explorer.application.module.service('sidebarTabService',
     explorer.components.explorer.sidebar.SidebarTabService);
 explorer.application.module.service('configService',

--- a/client/components/explorer/explorer-router-config.js
+++ b/client/components/explorer/explorer-router-config.js
@@ -1,0 +1,50 @@
+/**
+ * @copyright Copyright 2015 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @fileoverview UI.Router configuration for the Explorer page.
+ *
+ * @author joemu@google.com (Joe Allan Muharsky)
+ */
+
+goog.provide('p3rf.perfkit.explorer.components.explorer.ExplorerRouterConfig');
+
+
+
+goog.scope(function() {
+  const explorer = p3rf.perfkit.explorer;
+
+
+  const EXPLORER_PARAMS = [
+    'dashboard', 'container', 'widget', 'tab', 'footerTab',
+    '{focusWidget:boolean}', '{showFooter:boolean}'];
+
+  /**
+   * Sets up the explorer routing for selection and focus.
+   *
+   * @param {!UIRouter.StateProviderService} $stateProvider
+   * @constructor
+   * @ngInject
+   */
+  explorer.components.explorer.ExplorerRouterConfig = function(
+      $stateProvider, $urlRouterProvider) {
+
+    $stateProvider.state('explorer-dashboard-edit', {
+      url: '/explore?' + EXPLORER_PARAMS.join('&'),
+      template: '<div></div>'
+    });
+  };
+
+
+});  // goog.scope

--- a/client/components/explorer/explorer-state-model.js
+++ b/client/components/explorer/explorer-state-model.js
@@ -1,0 +1,106 @@
+/**
+ * @copyright Copyright 2015 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @fileoverview Model classes for Explorer page state.
+ * @author joemu@google.com (Joe Allan Muharsky)
+ */
+
+goog.provide('p3rf.perfkit.explorer.components.explorer.ExplorerStateModel');
+
+
+goog.scope(function() {
+const explorer = p3rf.perfkit.explorer;
+
+
+/**
+ * Model class for listing and selecting entities.
+ *
+ * The .all property provides a dictionary of all entities, keyed by ID
+ * for fast lookup.  The AngularUI State Service stores the actual
+ * selection ID's, and the .selectedId and .selected properties reference
+ * this.
+ *
+ * @constructor
+ * @template T
+ * @ngInject
+ */
+explorer.components.explorer.ExplorerStateModel = function(
+    stateService, stateName) {
+  /**
+   * Provides a dictionary of all entities, keyed by ID.
+   * @export {!Object<string, T>}
+   */
+  this.all = {};
+
+  /**
+   * Returns the selected id.  This is stored in the state service/URL.
+   * If no item is selected, returns NULL.
+   */
+  Object.defineProperty(this, 'selectedId', {
+    /** @type {?string} */
+    get: function() {
+      if (stateService.params[stateName]) {
+        return stateService.params[stateName];
+      } else {
+        return null;
+      }
+    }
+  });
+
+  /**
+   * Returns the item matching the selected id.
+   */
+  Object.defineProperty(this, 'selected', {
+    /** @type {T} */
+    get: function() {
+      if (goog.isDefAndNotNull(this.selectedId)) {
+        let selected = this.all[this.selectedId];
+
+        if (goog.isDefAndNotNull(selected)) {
+          return selected;
+        }
+      }
+
+      return null;
+    }
+  });
+
+  /**
+   * Returns true if the selected id exists in the .all dictionary.
+   * Also returns true if selectedId is not specified. Otherwise,
+   * returns false.
+   */
+   Object.defineProperty(this, 'selectedIdIsValid', {
+     /** @type {boolean} */
+     get: function() {
+       if (!goog.isDefAndNotNull(this.selectedId)) {
+         return false;
+       }
+       return goog.isDefAndNotNull(this.all[this.selectedId]);
+     }
+   })
+};
+const ExplorerStateModel = explorer.components.explorer.ExplorerStateModel;
+
+
+/**
+ * Adds an item to the all dictionary, using the id as the key.
+ * @export
+ */
+ExplorerStateModel.prototype.add = function(item) {
+  this.all[item.model.id] = item;
+};
+
+});  // goog.scope

--- a/client/components/explorer/explorer-state-model.js
+++ b/client/components/explorer/explorer-state-model.js
@@ -19,9 +19,14 @@
 
 goog.provide('p3rf.perfkit.explorer.components.explorer.ExplorerStateModel');
 
+goog.require('p3rf.perfkit.explorer.components.error.ErrorService');
+goog.require('p3rf.perfkit.explorer.components.error.ErrorTypes');
+
 
 goog.scope(function() {
 const explorer = p3rf.perfkit.explorer;
+const ErrorService = explorer.components.error.ErrorService;
+const ErrorTypes = explorer.components.error.ErrorTypes;
 
 
 /**
@@ -37,7 +42,10 @@ const explorer = p3rf.perfkit.explorer;
  * @ngInject
  */
 explorer.components.explorer.ExplorerStateModel = function(
-    stateService, stateName) {
+    stateService, errorService, stateName) {
+  /** @private {!ErrorService} */
+  this.errorSvc_ = errorService;
+
   /**
    * Provides a dictionary of all entities, keyed by ID.
    * @export {!Object<string, T>}
@@ -100,7 +108,15 @@ const ExplorerStateModel = explorer.components.explorer.ExplorerStateModel;
  * @export
  */
 ExplorerStateModel.prototype.add = function(item) {
-  this.all[item.model.id] = item;
+  if (
+      goog.isDefAndNotNull(item) &&
+      goog.isDefAndNotNull(item.model) &&
+      goog.isDefAndNotNull(item.model.id)) {
+    this.all[item.model.id] = item;
+  } else {
+    this.errorSvc_.addError(ErrorTypes.Danger,
+        'add failed: item is invalid');
+  }
 };
 
 });  // goog.scope

--- a/client/components/explorer/explorer-state-model_test.js
+++ b/client/components/explorer/explorer-state-model_test.js
@@ -24,15 +24,17 @@ goog.require('p3rf.perfkit.explorer.components.explorer.ExplorerStateModel');
 
 fdescribe('ExplorerStateModel', function() {
   var $rootScope, $state;
+  var errorSvc;
 
   const explorer = p3rf.perfkit.explorer;
   const ExplorerStateModel = explorer.components.explorer.ExplorerStateModel;
 
   beforeEach(module('explorer'));
 
-  beforeEach(inject(function(_$rootScope_, _$state_) {
+  beforeEach(inject(function(_$rootScope_, _$state_, errorService) {
     $rootScope = _$rootScope_;
     $state = _$state_;
+    errorSvc = errorService;
   }));
 
   describe('property', function() {
@@ -43,7 +45,7 @@ fdescribe('ExplorerStateModel', function() {
     var item2 = {model: {id: '2', title: 'item 2'}};
 
     beforeEach(inject(function() {
-      expectedModel = new ExplorerStateModel($state, expectedStateName);
+      expectedModel = new ExplorerStateModel($state, errorSvc, expectedStateName);
 
       expectedModel.all[item1.model.id] = item1;
       expectedModel.all[item2.model.id] = item2;
@@ -66,6 +68,22 @@ fdescribe('ExplorerStateModel', function() {
 
         expect(Object.keys(expectedModel.all).length).toEqual(2);
         expect(expectedModel.all[item2.model.id]).toEqual(item2a);
+      });
+
+      it('should log an error if an invalid item is provided', function() {
+        spyOn(errorSvc, 'addError');
+
+        expectedModel.add('invalid');
+
+        expect(errorSvc.addError).toHaveBeenCalled();
+      });
+
+      it('should log an error if a NULL id is provided', function() {
+        spyOn(errorSvc, 'addError');
+
+        expectedModel.add({model: {id: null}});
+
+        expect(errorSvc.addError).toHaveBeenCalled();
       });
     });
 

--- a/client/components/explorer/explorer-state-model_test.js
+++ b/client/components/explorer/explorer-state-model_test.js
@@ -22,7 +22,7 @@
 goog.require('p3rf.perfkit.explorer.components.explorer.ExplorerStateModel');
 
 
-fdescribe('ExplorerStateModel', function() {
+describe('ExplorerStateModel', function() {
   var $rootScope, $state;
   var errorSvc;
 

--- a/client/components/explorer/explorer-state-model_test.js
+++ b/client/components/explorer/explorer-state-model_test.js
@@ -1,0 +1,142 @@
+/**
+ * @copyright Copyright 2015 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @fileoverview Tests for ExplorerStateModel, which encapsulates the list
+ * and selection properties for Explorer.
+ *
+ * @author joemu@google.com (Joe Allan Muharsky)
+ */
+
+goog.require('p3rf.perfkit.explorer.components.explorer.ExplorerStateModel');
+
+
+fdescribe('ExplorerStateModel', function() {
+  var $rootScope, $state;
+
+  const explorer = p3rf.perfkit.explorer;
+  const ExplorerStateModel = explorer.components.explorer.ExplorerStateModel;
+
+  beforeEach(module('explorer'));
+
+  beforeEach(inject(function(_$rootScope_, _$state_) {
+    $rootScope = _$rootScope_;
+    $state = _$state_;
+  }));
+
+  describe('property', function() {
+    var expectedModel;
+    var expectedStateName = 'widget';
+
+    var item1 = {model: {id: '1', title: 'item 1'}};
+    var item2 = {model: {id: '2', title: 'item 2'}};
+
+    beforeEach(inject(function() {
+      expectedModel = new ExplorerStateModel($state, expectedStateName);
+
+      expectedModel.all[item1.model.id] = item1;
+      expectedModel.all[item2.model.id] = item2;
+    }));
+
+    describe('add', function() {
+      var item3 = {model: {id: '3', title: 'item 3'}};
+
+      it('should add an item to the .all collection', function() {
+        expectedModel.add(item3);
+
+        expect(expectedModel.all[item3.model.id]).toEqual(item3);
+      });
+
+      it('should replace an item if the id already exists', function() {
+        expect(Object.keys(expectedModel.all).length).toEqual(2);
+
+        var item2a = {model: {id: item2.model.id, title: 'item 3a'}};
+        expectedModel.add(item2a);
+
+        expect(Object.keys(expectedModel.all).length).toEqual(2);
+        expect(expectedModel.all[item2.model.id]).toEqual(item2a);
+      });
+    });
+
+    describe('selectedId', function() {
+      it('should return null by default', function() {
+        expect(expectedModel.selectedId).toBeNull();
+      });
+
+      it('should return the state param', function() {
+        var params = {};
+        params[expectedStateName] = item1.model.id;
+
+        $state.go('explorer-dashboard-edit', params);
+        $rootScope.$apply();
+
+        expect(expectedModel.selectedId).toEqual(item1.model.id);
+      });
+    });
+
+    describe('selectedIdIsValid', function() {
+      it('should return true if no id is provided', function() {
+        expect(expectedModel.selectedId).toBeNull();
+        expect(expectedModel.selectedIdIsValid).toBeFalse();
+      });
+
+      it('should return true if the id exists', function() {
+        var params = {};
+        params[expectedStateName] = item1.model.id;
+
+        $state.go('explorer-dashboard-edit', params);
+        $rootScope.$apply();
+
+        expect(expectedModel.selectedIdIsValid).toBeTrue();
+      });
+
+      it('should return false if the id does not exists', function() {
+        var params = {};
+        params[expectedStateName] = 'invalid';
+
+        $state.go('explorer-dashboard-edit', params);
+        $rootScope.$apply();
+
+        expect(expectedModel.selectedIdIsValid).toBeFalse();
+      });
+    });
+
+    describe('selected', function() {
+      it('should return null by default', function() {
+        expect(expectedModel.selected).toBeNull();
+      });
+
+      it('should return null when an invalid id is provided', function() {
+        var params = {};
+        params[expectedStateName] = 'invalid';
+
+        $state.go('explorer-dashboard-edit', params);
+        $rootScope.$apply();
+
+        expect(expectedModel.selected).toBeNull();
+      });
+
+      it('should return the object when a valid id is provided', function() {
+        var params = {};
+        params[expectedStateName] = item1.model.id;
+
+        $state.go('explorer-dashboard-edit', params);
+        $rootScope.$apply();
+
+        expect(expectedModel.selected).toEqual(item1);
+      });
+    });
+  });
+
+});

--- a/client/components/explorer/explorer-state-service.js
+++ b/client/components/explorer/explorer-state-service.js
@@ -1,0 +1,104 @@
+/**
+ * @copyright Copyright 2015 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @fileoverview Service for state and content of the Explorer page.
+ * @author joemu@google.com (Joe Allan Muharsky)
+ */
+
+goog.provide('p3rf.perfkit.explorer.components.explorer.ExplorerStateService');
+
+goog.require('p3rf.perfkit.explorer.components.error.ErrorService');
+goog.require('p3rf.perfkit.explorer.components.error.ErrorTypes');
+goog.require('p3rf.perfkit.explorer.components.explorer.ExplorerStateModel');
+
+
+
+goog.scope(function() {
+const explorer = p3rf.perfkit.explorer;
+const ErrorService = explorer.components.error.ErrorService;
+const ErrorTypes = explorer.components.error.ErrorTypes;
+const ExplorerStateModel = explorer.components.explorer.ExplorerStateModel;
+
+
+/**
+ * Service that provides state and content for the Explorer page..
+ * @constructor
+ * @ngInject
+ */
+explorer.components.explorer.ExplorerStateService = function(
+    $state, errorService) {
+  /** @export {!AngularUI.State} */
+  this.$state = $state;
+
+  /** @private {!ErrorService} */
+  this.errorSvc_ = errorService;
+
+  /**
+   * Provides storage for a list of dashboards and selection context.
+   * @export {?DashboardModel}
+   */
+  this.selectedDashboard = null;
+
+  /**
+   * Provides storage for a list of containers and selection context.
+   * @export {!ExplorerStateModel<ContainerWidgetModel>}
+   */
+  this.containers =
+      /** @type {!ExplorerStateModel<ContainerWidgetModel>} */
+      (new ExplorerStateModel($state, 'container'));
+
+  /**
+   * Provides storage for a list of widgets and selection context.
+   * @export {!ExplorerStateModel<WidgetModel>}
+   */
+  this.widgets =
+      /** @type {!ExplorerStateModel<WidgetModel>} */
+      (new ExplorerStateModel($state, 'widget'));
+};
+const ExplorerStateService = explorer.components.explorer.ExplorerStateService;
+
+
+ExplorerStateService.prototype.selectWidget = function(
+    containerId, widgetId) {
+  let params = {};
+  let valid = true;
+
+  if (containerId) {
+    if (goog.isDefAndNotNull(this.containers.all[containerId])) {
+      params['container'] = containerId;
+    } else {
+      this.errorSvc_.addError(ErrorTypes.DANGER,
+        'Selection failed: container id ' + containerId + ' does not exist.');
+      valid = false;
+    }
+  }
+
+  if (widgetId) {
+    if (goog.isDefAndNotNull(this.widgets.all[widgetId])) {
+      params['widget'] = widgetId;
+    } else {
+      this.errorSvc_.addError(ErrorTypes.DANGER,
+        'Selection failed: widget id ' + widgetId + ' does not exist.');
+      valid = false;
+    }
+  }
+
+  if (valid) {
+    this.$state.go('explorer-dashboard-edit', params);
+  }
+};
+
+
+});  // goog.scope

--- a/client/components/explorer/explorer-state-service.js
+++ b/client/components/explorer/explorer-state-service.js
@@ -57,7 +57,7 @@ explorer.components.explorer.ExplorerStateService = function(
    */
   this.containers =
       /** @type {!ExplorerStateModel<ContainerWidgetModel>} */
-      (new ExplorerStateModel($state, 'container'));
+      (new ExplorerStateModel($state, errorService, 'container'));
 
   /**
    * Provides storage for a list of widgets and selection context.
@@ -65,7 +65,7 @@ explorer.components.explorer.ExplorerStateService = function(
    */
   this.widgets =
       /** @type {!ExplorerStateModel<WidgetModel>} */
-      (new ExplorerStateModel($state, 'widget'));
+      (new ExplorerStateModel($state, errorService, 'widget'));
 };
 const ExplorerStateService = explorer.components.explorer.ExplorerStateService;
 

--- a/client/components/explorer/explorer-state-service_test.js
+++ b/client/components/explorer/explorer-state-service_test.js
@@ -43,16 +43,12 @@ describe('ExplorerStateService', function() {
   describe('should correctly initialize', function() {
     var expectedModel;
 
-    beforeEach(inject(function() {
-      expectedModel = new ExplorerStateModel();
-    }));
-
     it('the containers list', function() {
-      expect(svc.containers).toEqual(expectedModel);
+      expect(svc.containers).not.toBeNull();
     });
 
     it('the widgets list', function() {
-      expect(svc.widgets).toEqual(expectedModel);
+      expect(svc.widgets).not.toBeNull();
     });
   });
 
@@ -71,7 +67,7 @@ describe('ExplorerStateService', function() {
       svc.containers.add(container2);
     }));
 
-    fdescribe('selectWidget', function() {
+    describe('selectWidget', function() {
       it('should select items by id', function() {
         svc.selectWidget(container2.model.id, widget2.model.id);
         $rootScope.$apply();

--- a/client/components/explorer/explorer-state-service_test.js
+++ b/client/components/explorer/explorer-state-service_test.js
@@ -1,0 +1,114 @@
+/**
+ * @copyright Copyright 2015 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @fileoverview Tests for ExplorerStateService, which tracks and manages
+ * the state of the Explorer page.
+ *
+ * @author joemu@google.com (Joe Allan Muharsky)
+ */
+
+goog.require('p3rf.perfkit.explorer.components.explorer.ExplorerStateService');
+goog.require('p3rf.perfkit.explorer.components.explorer.ExplorerStateModel');
+
+
+describe('ExplorerStateService', function() {
+  var svc, $rootScope, $state;
+  var errorSvc;
+
+  const explorer = p3rf.perfkit.explorer;
+  const ExplorerStateModel = explorer.components.explorer.ExplorerStateModel;
+
+  beforeEach(module('explorer'));
+
+  beforeEach(inject(function(
+      _$rootScope_, _$state_, explorerStateService, errorService) {
+    $rootScope = _$rootScope_;
+    $state = _$state_;
+    svc = explorerStateService;
+    errorSvc = errorService;
+  }));
+
+  describe('should correctly initialize', function() {
+    var expectedModel;
+
+    beforeEach(inject(function() {
+      expectedModel = new ExplorerStateModel();
+    }));
+
+    it('the containers list', function() {
+      expect(svc.containers).toEqual(expectedModel);
+    });
+
+    it('the widgets list', function() {
+      expect(svc.widgets).toEqual(expectedModel);
+    });
+  });
+
+  describe('method', function() {
+    var widget1, widget2, container1, container2;
+
+    beforeEach(inject(function() {
+      widget1 = {model: {id: 'w1', title: 'widget 1'}};
+      widget2 = {model: {id: 'w2', title: 'widget 2'}};
+      container1 = {model: {id: 'c1', title: 'container 1'}};
+      container2 = {model: {id: 'c2', title: 'container 2'}};
+
+      svc.widgets.add(widget1);
+      svc.widgets.add(widget2);
+      svc.containers.add(container1);
+      svc.containers.add(container2);
+    }));
+
+    fdescribe('selectWidget', function() {
+      it('should select items by id', function() {
+        svc.selectWidget(container2.model.id, widget2.model.id);
+        $rootScope.$apply();
+
+        expect(svc.containers.selected).toEqual(container2);
+        expect(svc.widgets.selected).toEqual(widget2);
+      });
+
+      it('should unselect items when NULL is passed', function() {
+        svc.selectWidget(null, null);
+        $rootScope.$apply();
+
+        expect(svc.containers.selected).toBeNull();
+        expect(svc.widgets.selected).toBeNull();
+      });
+
+      describe('should write to the log when providing an invalid',
+          function() {
+        beforeEach(inject(function() {
+          spyOn(errorSvc, 'addError');
+        }));
+
+        it('containerId', function() {
+          svc.selectWidget('invalid', widget1.model.id);
+          expect(errorSvc.addError).toHaveBeenCalled();
+        });
+
+        it('widgetId', function() {
+          svc.selectWidget(container1.model.id, 'invalid');
+          expect(errorSvc.addError).toHaveBeenCalled();
+        });
+
+        it('containerId and widgetId', function() {
+          svc.selectWidget('invalid', 'invalid');
+          expect(errorSvc.addError.calls.count()).toEqual(2);
+        });
+      });
+    });
+  });
+});

--- a/client/karma.conf.js
+++ b/client/karma.conf.js
@@ -15,6 +15,7 @@ module.exports = function(config) {
       'bower_components/angular-animate/angular-animate.js',
       'bower_components/angular-mocks/angular-mocks.js',
       'bower_components/angular-material/angular-material.js',
+      'bower_components/angular-ui-router/release/angular-ui-router.js',
       'bower_components/codemirror/lib/codemirror.js',
       'bower_components/angular-ui-grid/ui-grid.js',
       'bower_components/angular-bootstrap/ui-bootstrap-tpls.js',


### PR DESCRIPTION
Adds the management classes (Service and Model) for Explorer State, based on the current values in the Angular UI Router state service.  At the moment, these services are loaded but unused; additional PR's will consolidate the dashboard's selection state into this service.

For more info, see the [Design Doc](https://docs.google.com/presentation/d/1e6CFF4-qdCKnNROCE4EL4qFjewtnBHxMCJ1IXJZ8N6k/edit#slide=id.p)