### PR TITLE
Initial Column Style support

### DIFF
--- a/client/app.js
+++ b/client/app.js
@@ -70,6 +70,11 @@ goog.require('p3rf.perfkit.explorer.components.widget.data_viz.gviz.getGvizChart
 goog.require('p3rf.perfkit.explorer.components.widget.data_viz.gviz.getGvizDataTable');
 goog.require('p3rf.perfkit.explorer.components.widget.data_viz.gviz.getGvizDataView');
 goog.require('p3rf.perfkit.explorer.components.widget.data_viz.gviz.gvizChart');
+goog.require('p3rf.perfkit.explorer.components.widget.data_viz.gviz.column_style.ColumnStyleConfigDirective');
+goog.require('p3rf.perfkit.explorer.components.widget.data_viz.gviz.column_style.ColumnStyleDirective');
+goog.require('p3rf.perfkit.explorer.components.widget.data_viz.gviz.column_style.ColumnStyleService');
+goog.require('p3rf.perfkit.explorer.components.widget.data_viz.gviz.column_style.ColumnStyleToolbarDirective');
+goog.require('p3rf.perfkit.explorer.components.widget.data_viz.WidgetEditorCtrl');
 goog.require('p3rf.perfkit.explorer.components.widget.perfkitWidget');
 goog.require('p3rf.perfkit.explorer.components.widget.WidgetConfigDirective');
 goog.require('p3rf.perfkit.explorer.components.widget.query.builder.FieldCubeDataService');
@@ -171,6 +176,8 @@ explorer.application.module.service('chartWrapperService',
     explorer.components.widget.data_viz.gviz.ChartWrapperService);
 explorer.application.module.service('gvizEvents',
     explorer.components.widget.data_viz.gviz.GvizEvents);
+explorer.application.module.service('columnStyleService',
+    explorer.components.widget.data_viz.gviz.column_style.ColumnStyleService);
 explorer.application.module.service('widgetEditorService',
     explorer.components.widget.data_viz.WidgetEditorService);
 explorer.application.module.service('dataViewService',
@@ -277,6 +284,12 @@ explorer.application.module.directive('widgetToolbar',
 /** BQ PerfKit Widget directives. */
 explorer.application.module.directive('chartConfig',
     explorer.components.widget.data_viz.gviz.ChartConfigDirective);
+explorer.application.module.directive('columnStyle',
+    explorer.components.widget.data_viz.gviz.column_style.ColumnStyleDirective);
+explorer.application.module.directive('columnStyleConfig',
+    explorer.components.widget.data_viz.gviz.column_style.ColumnStyleConfigDirective);
+explorer.application.module.directive('columnStyleToolbar',
+    explorer.components.widget.data_viz.gviz.column_style.ColumnStyleToolbarDirective);
 explorer.application.module.directive('gvizChartWidget',
     explorer.components.widget.data_viz.gviz.gvizChart);
 explorer.application.module.directive('queryResultConfig',

--- a/client/components/dashboard/dashboard-version-service.js
+++ b/client/components/dashboard/dashboard-version-service.js
@@ -49,6 +49,7 @@ goog.require('p3rf.perfkit.explorer.components.dashboard.versions.DashboardSchem
 goog.require('p3rf.perfkit.explorer.components.dashboard.versions.DashboardSchemaV6');
 goog.require('p3rf.perfkit.explorer.components.dashboard.versions.DashboardSchemaV7');
 goog.require('p3rf.perfkit.explorer.components.dashboard.versions.DashboardSchemaV8');
+goog.require('p3rf.perfkit.explorer.components.dashboard.versions.DashboardSchemaV9');
 
 goog.require('p3rf.perfkit.explorer.components.dashboard.DashboardVersionModel');
 
@@ -171,11 +172,13 @@ DashboardVersionService.prototype.getDashboardVersion = function(dashboard) {
   throw new Error('The model does not appear to be a valid dashboard.');
 };
 
+
 /**
  * Initializes the version list.
  */
 DashboardVersionService.prototype.initVersions = function() {
   return [
+    new versions.DashboardSchemaV9(),
     new versions.DashboardSchemaV8(),
     new versions.DashboardSchemaV7(),
     new versions.DashboardSchemaV6(),

--- a/client/components/dashboard/versions/dashboard-schema_09.js
+++ b/client/components/dashboard/versions/dashboard-schema_09.js
@@ -1,0 +1,60 @@
+/**
+ * @copyright Copyright 2015 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @fileoverview Version info class, including update and verify scripts.
+ *
+ * v8   2015-Aug    Adds a chart.columns array to store column styles.
+ *
+ * @author joemu@google.com (Joe Allan Muharsky)
+ */
+
+
+goog.provide('p3rf.perfkit.explorer.components.dashboard.versions.DashboardSchemaV9');
+
+goog.require('p3rf.perfkit.explorer.components.dashboard.versions.DashboardVersionUtil');
+
+
+goog.scope(function() {
+  const explorer = p3rf.perfkit.explorer;
+  const DashboardVersionUtil = explorer.components.dashboard.versions.DashboardVersionUtil;
+
+  /**
+   * @constructor
+   */
+  explorer.components.dashboard.versions.DashboardSchemaV9 = function() {
+    this.version = '9';
+  };
+  const DashboardSchema = (
+      explorer.components.dashboard.versions.DashboardSchemaV9);
+
+  DashboardSchema.prototype.verify = function(dashboard) {
+    return DashboardVersionUtil.VerifyDashboard(
+        dashboard, null, function(widget) {
+      if (!goog.isDef(widget.chart.columns)) {
+        return false;
+      }
+
+      return goog.isArray(widget.chart.columns);
+    });
+  };
+
+  DashboardSchema.prototype.update = function(dashboard) {
+    DashboardVersionUtil.UpdateDashboard(dashboard, null, function(widget) {
+      if (!goog.isDef(widget.chart.columns)) {
+        widget.chart.columns = [];
+      }
+    });
+  };
+});

--- a/client/components/explorer/explorer-toolbar-directive.html
+++ b/client/components/explorer/explorer-toolbar-directive.html
@@ -36,7 +36,7 @@
     </div>
 
     <div ng-switch-when="widget.columns">
-      <column-style-toolbar ng-model="ctrl.dashboardSvc.selectedWidget.model" />
+      <column-style-toolbar ng-model="ctrl.dashboardSvc.selectedWidget" />
     </div>
 
     <div ng-switch-when="widget.alert.detector">

--- a/client/components/explorer/explorer-toolbar-directive.html
+++ b/client/components/explorer/explorer-toolbar-directive.html
@@ -35,6 +35,10 @@
           ng-model="ctrl.dashboardSvc.selectedWidget.model" />
     </div>
 
+    <div ng-switch-when="widget.columns">
+      <column-style-toolbar ng-model="ctrl.dashboardSvc.selectedWidget.model" />
+    </div>
+
     <div ng-switch-when="widget.alert.detector">
       <alert-toolbar
           ng-model="ctrl.dashboardSvc.selectedWidget.model" />

--- a/client/components/explorer/sidebar/sidebar-directive.html
+++ b/client/components/explorer/sidebar/sidebar-directive.html
@@ -57,7 +57,7 @@
       </div>
 
       <div ng-switch-when="widget.columns">
-        <column-style-config ng-model="dashboardSvc.selectedWidget" />
+        <column-style-config ng-model="dashboardSvc.selectedWidget.model" />
       </div>
 
       <div ng-switch-default>UNSUPPORTED TYPE: {{ tabSvc.selectedTab.id }}</div>

--- a/client/components/explorer/sidebar/sidebar-directive.html
+++ b/client/components/explorer/sidebar/sidebar-directive.html
@@ -57,7 +57,7 @@
       </div>
 
       <div ng-switch-when="widget.columns">
-        <column-style-config ng-model="dashboardSvc.selectedWidget.model" />
+        <column-style-config ng-model="dashboardSvc.selectedWidget" />
       </div>
 
       <div ng-switch-default>UNSUPPORTED TYPE: {{ tabSvc.selectedTab.id }}</div>

--- a/client/components/explorer/sidebar/sidebar-directive.html
+++ b/client/components/explorer/sidebar/sidebar-directive.html
@@ -56,6 +56,10 @@
         <chart-config ng-model="dashboardSvc.selectedWidget.model" />
       </div>
 
+      <div ng-switch-when="widget.columns">
+        <column-style-config ng-model="dashboardSvc.selectedWidget" />
+      </div>
+
       <div ng-switch-default>UNSUPPORTED TYPE: {{ tabSvc.selectedTab.id }}</div>
     </div>
   </div>

--- a/client/components/explorer/sidebar/sidebar-tab-service.js
+++ b/client/components/explorer/sidebar/sidebar-tab-service.js
@@ -51,6 +51,10 @@ explorer.components.explorer.sidebar.SIDEBAR_TABS = [
   {id: 'widget.config', title: 'Widget', iconClass: 'fa fa-font',
     hint: 'Widget title and appearance', requireWidget: true,
     tabClass: 'widget-tab', panelTitleClass: 'widget-panel-title',
+    panelClass: 'widget-panel', toolbarClass: 'widget-toolbar'},
+  {id: 'widget.columns', title: 'Columns', iconClass: 'fa fa-columns',
+    hint: 'Column styling and order', requireWidget: true,
+    tabClass: 'widget-tab', panelTitleClass: 'widget-panel-title',
     panelClass: 'widget-panel', toolbarClass: 'widget-toolbar'}
 ];
 const SIDEBAR_TABS = explorer.components.explorer.sidebar.SIDEBAR_TABS;

--- a/client/components/widget/data_viz/gviz/column_style/column-style-config-directive.html
+++ b/client/components/widget/data_viz/gviz/column_style/column-style-config-directive.html
@@ -1,0 +1,12 @@
+<div class="column-style-list">
+  <column-style
+      ng-model="column"
+      widget-model="ngModel"
+      ng-repeat="column in ngModel.chart.columns track by $index">
+  </column-style>
+  <div class="column-style-insert-row">
+    <input class="form-control column-style-insert-control"
+        ng-click="columnStyleSvc.addColumn(ngModel)"
+        readonly placeholder="click to add">
+  </div>
+</div>

--- a/client/components/widget/data_viz/gviz/column_style/column-style-config-directive.html
+++ b/client/components/widget/data_viz/gviz/column_style/column-style-config-directive.html
@@ -1,12 +1,12 @@
 <div class="column-style-list">
   <column-style
       ng-model="column"
-      widget-model="ngModel"
-      ng-repeat="column in ngModel.chart.columns track by $index">
+      widget-config="ngModel"
+      ng-repeat="column in ngModel.model.chart.columns track by $index">
   </column-style>
   <div class="column-style-insert-row">
     <input class="form-control column-style-insert-control"
-        ng-click="columnStyleSvc.addColumn(ngModel)"
+        ng-click="columnStyleSvc.addColumn(ngModel.model)"
         readonly placeholder="click to add">
   </div>
 </div>

--- a/client/components/widget/data_viz/gviz/column_style/column-style-config-directive.html
+++ b/client/components/widget/data_viz/gviz/column_style/column-style-config-directive.html
@@ -1,12 +1,21 @@
-<div class="column-style-list">
-  <column-style
-      ng-model="column"
-      widget-config="ngModel"
-      ng-repeat="column in ngModel.model.chart.columns track by $index">
-  </column-style>
-  <div class="column-style-insert-row">
-    <input class="form-control column-style-insert-control"
-        ng-click="columnStyleSvc.addColumn(ngModel.model)"
-        readonly placeholder="click to add">
+<div>
+  <div class="pk-sidebar-note">
+    You can define the title and order of your columns below.  Hover over an element
+    below, or toolbar option to the right, to learn more.
+  </div>
+  <div class="column-style-list">
+    <column-style
+        ng-model="column"
+        widget-config="ngModel"
+        ng-repeat="column in ngModel.model.chart.columns track by $index">
+    </column-style>
+    <div class="column-style-insert-row">
+      <input class="form-control column-style-insert-control"
+          ng-click="columnStyleSvc.addColumnsFromDatasource(ngModel)"
+          readonly placeholder="add from datasource">
+      <md-tooltip md-direction="bottom">
+        Adds a <b>Column Style</b> for each field in your selected widget's <b>Query</b>
+      </md-tooltip>
+    </div>
   </div>
 </div>

--- a/client/components/widget/data_viz/gviz/column_style/column-style-config-directive.js
+++ b/client/components/widget/data_viz/gviz/column_style/column-style-config-directive.js
@@ -38,7 +38,7 @@ gviz.column_style.ColumnStyleConfigDirective = function() {
     replace: true,
     transclude: false,
     scope: {
-      /** @type {!ChartWidgetModel} */
+      /** @type {!ChartWidgetConfig} */
       'ngModel': '='
     },
     templateUrl: '/static/components/widget/data_viz/gviz/column_style/column-style-config-directive.html',

--- a/client/components/widget/data_viz/gviz/column_style/column-style-config-directive.js
+++ b/client/components/widget/data_viz/gviz/column_style/column-style-config-directive.js
@@ -1,0 +1,53 @@
+/**
+ * @copyright Copyright 2015 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @fileoverview ColumnStyleDirective encapsulates HTML, style
+ *     and behavior for configuring columns.
+ * @author joemu@google.com (Joe Allan Muharsky)
+ */
+
+goog.provide('p3rf.perfkit.explorer.components.widget.data_viz.gviz.column_style.ColumnStyleConfigDirective');
+
+
+goog.scope(function() {
+const explorer = p3rf.perfkit.explorer;
+const gviz = explorer.components.widget.data_viz.gviz;
+
+
+/**
+ * See module docstring for more information about purpose and usage.
+ *
+ * @return {Object} Directive definition object.
+ * @ngInject
+ */
+gviz.column_style.ColumnStyleConfigDirective = function() {
+  return {
+    restrict: 'E',
+    replace: true,
+    transclude: false,
+    scope: {
+      /** @type {!ChartWidgetModel} */
+      'ngModel': '='
+    },
+    templateUrl: '/static/components/widget/data_viz/gviz/column_style/column-style-config-directive.html',
+    controller: ['$scope', 'columnStyleService', function($scope, columnStyleService) {
+
+      /** @export {!ColumnStyleService} */
+      $scope.columnStyleSvc = columnStyleService;
+    }]
+  };
+};
+
+});  // goog.scope

--- a/client/components/widget/data_viz/gviz/column_style/column-style-directive.css
+++ b/client/components/widget/data_viz/gviz/column_style/column-style-directive.css
@@ -1,0 +1,25 @@
+.column-style-item {
+  border-bottom: 1px solid #ccc;
+  cursor: pointer;
+  margin-bottom: 0;
+  margin-left: -8px;
+  margin-right: -8px;
+  padding-bottom: 12px;
+  padding-left: 12px;
+  padding-right: 8px;
+  padding-top: 12px;
+}
+
+.column-style-insert-row {
+  margin-top: 16px;
+}
+
+.column-style-item-selected {
+  background-color: #e3f2fd; /** blue:50 */
+  border-left: 4px solid #1565C0; /** blue:800 */
+  padding-left: 8px;
+}
+
+.column-style-insert-control:hover {
+  cursor: pointer !important;
+}

--- a/client/components/widget/data_viz/gviz/column_style/column-style-directive.css
+++ b/client/components/widget/data_viz/gviz/column_style/column-style-directive.css
@@ -20,6 +20,17 @@
   padding-left: 8px;
 }
 
+.column-style-item-invalid {
+  background-color: #ffecb3; /** amber:100 */
+  padding-left: 8px;
+}
+
+.column-style-item-invalid.column-style-item-selected {
+  background-color: #ffecb3; /** orange:100 */
+  border-left: 4px solid #ff8f00; /** orange:800 */
+  padding-left: 8px;
+}
+
 .column-style-insert-control:hover {
   cursor: pointer !important;
 }

--- a/client/components/widget/data_viz/gviz/column_style/column-style-directive.html
+++ b/client/components/widget/data_viz/gviz/column_style/column-style-directive.html
@@ -3,29 +3,39 @@
      ng-class="{'column-style-item-selected': isSelected()}"
      ng-focus="select()"
      ng-click="select()">
-  <div class="pk-sidebar-item-label">
-    column id
+  <div>
+    <div class="pk-sidebar-item-label">
+      field name
+    </div>
+    <div class="input-group pk-sidebar-item-value">
+      <input
+          class="form-control widget-column-style-id"
+          placeholder="column id"
+          ng-focus="select()"
+          ng-model="ngModel.column_id">
+      <span class="input-group-addon">
+        <i class="glyphicon glyphicon-remove"
+          ng-focus="select()"
+          ng-click="remove()"></i>
+      </span>
+    </div>
+    <md-tooltip md-direction="right">
+      The name of the <b>Field</b> from your <b>Query</b>
+    </md-tooltip>
   </div>
-  <div class="input-group pk-sidebar-item-value">
-    <input
-        class="form-control widget-column-style-id"
-        placeholder="column id"
-        ng-focus="select()"
-        ng-model="ngModel.column_id">
-    <span class="input-group-addon">
-      <i class="glyphicon glyphicon-remove"
-         ng-focus="select()"
-         ng-click="remove()"></i>
-    </button>
-  </div>
-  <div class="pk-sidebar-item-label">
-    title
-  </div>
-  <div class="pk-sidebar-item-value">
-    <input
-        class="form-control widget-column-style-title"
-        placeholder="{{ ngModel.column_id }}"
-        ng-focus="select()"
-        ng-model="ngModel.title">
+  <div>
+    <div class="pk-sidebar-item-label">
+      title
+    </div>
+    <div class="pk-sidebar-item-value">
+      <input
+          class="form-control widget-column-style-title"
+          placeholder="{{ ngModel.column_id }}"
+          ng-focus="select()"
+          ng-model="ngModel.title">
+    </div>
+    <md-tooltip md-direction="right">
+      A <b>readable</b> title to use in place of the field name
+    </md-tooltip>
   </div>
 </div>

--- a/client/components/widget/data_viz/gviz/column_style/column-style-directive.html
+++ b/client/components/widget/data_viz/gviz/column_style/column-style-directive.html
@@ -1,6 +1,7 @@
 <div class="pk-sidebar-item column-style-item"
      tabindex="0"
-     ng-class="{'column-style-item-selected': isSelected()}"
+     ng-class="{'column-style-item-selected': isSelected(),
+                'column-style-item-invalid': !isValid()}"
      ng-focus="select()"
      ng-click="select()">
   <div>
@@ -13,6 +14,13 @@
           placeholder="column id"
           ng-focus="select()"
           ng-model="ngModel.column_id">
+      <span class="input-group-addon"
+          ng-show="!isValid()">
+        <i class="fa fa-exclamation-triangle"></i>
+        <md-tooltip>
+          The column does not exist in the dataTable
+        <md-tooltip>
+      </span>
       <span class="input-group-addon">
         <i class="glyphicon glyphicon-remove"
           ng-focus="select()"

--- a/client/components/widget/data_viz/gviz/column_style/column-style-directive.html
+++ b/client/components/widget/data_viz/gviz/column_style/column-style-directive.html
@@ -1,0 +1,31 @@
+<div class="pk-sidebar-item column-style-item"
+     tabindex="0"
+     ng-class="{'column-style-item-selected': isSelected()}"
+     ng-focus="select()"
+     ng-click="select()">
+  <div class="pk-sidebar-item-label">
+    column id
+  </div>
+  <div class="input-group pk-sidebar-item-value">
+    <input
+        class="form-control widget-column-style-id"
+        placeholder="column id"
+        ng-focus="select()"
+        ng-model="ngModel.column_id">
+    <span class="input-group-addon">
+      <i class="glyphicon glyphicon-remove"
+         ng-focus="select()"
+         ng-click="remove()"></i>
+    </button>
+  </div>
+  <div class="pk-sidebar-item-label">
+    title
+  </div>
+  <div class="pk-sidebar-item-value">
+    <input
+        class="form-control widget-column-style-title"
+        placeholder="{{ ngModel.column_id }}"
+        ng-focus="select()"
+        ng-model="ngModel.title">
+  </div>
+</div>

--- a/client/components/widget/data_viz/gviz/column_style/column-style-directive.js
+++ b/client/components/widget/data_viz/gviz/column_style/column-style-directive.js
@@ -1,0 +1,75 @@
+/**
+ * @copyright Copyright 2015 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @fileoverview ColumnStyleDirective encapsulates HTML, style
+ *     and behavior for configuring styles for a single column.
+ * @author joemu@google.com (Joe Allan Muharsky)
+ */
+
+goog.provide('p3rf.perfkit.explorer.components.widget.data_viz.gviz.column_style.ColumnStyleDirective');
+
+
+goog.scope(function() {
+const explorer = p3rf.perfkit.explorer;
+const gviz = explorer.components.widget.data_viz.gviz;
+
+
+/**
+ * See module docstring for more information about purpose and usage.
+ *
+ * @return {Object} Directive definition object.
+ * @ngInject
+ */
+gviz.column_style.ColumnStyleDirective = function(
+    queryEditorService) {
+  return {
+    restrict: 'E',
+    replace: true,
+    transclude: false,
+    scope: {
+      /** @type {!ColumnStyleModel} */
+      'ngModel': '=',
+      'widgetModel': '='
+    },
+    templateUrl: '/static/components/widget/data_viz/gviz/column_style/column-style-directive.html',
+    controller: ['$scope', 'columnStyleService', 'arrayUtilService', function(
+        $scope, columnStyleService, arrayUtilService) {
+
+      /**
+       * Returns true if the column provided by ngModel is selected, otherwise false.
+       * @return {boolean}
+       */
+      $scope.isSelected = function() {
+        return (columnStyleService.selectedColumn == $scope.ngModel);
+      }
+
+      /**
+       * Removes the column provided by ngModel from the widget config.
+       */
+      $scope.remove = function() {
+        columnStyleService.removeColumn($scope.widgetModel, $scope.ngModel);
+      }
+
+      /**
+       * Selects the column provided by ngModel.
+       */
+      $scope.select = function() {
+        columnStyleService.selectedColumn = $scope.ngModel;
+      }
+    }]
+  };
+};
+
+});  // goog.scope

--- a/client/components/widget/data_viz/gviz/column_style/column-style-directive.js
+++ b/client/components/widget/data_viz/gviz/column_style/column-style-directive.js
@@ -91,6 +91,15 @@ gviz.column_style.ColumnStyleDirective = function() {
       $scope.select = function() {
         columnStyleService.selectedColumn = $scope.ngModel;
       }
+
+      /**
+       * Returns true if the column id exists in the dataTable, otherwise false.
+       */
+      $scope.isValid = function() {
+        return (columnStyleService.getColumnIndex(
+            $scope.ngModel.column_id,
+            $scope.widgetConfig.state().datasource.data) !== -1);
+      }
     }]
   };
 };

--- a/client/components/widget/data_viz/gviz/column_style/column-style-directive.js
+++ b/client/components/widget/data_viz/gviz/column_style/column-style-directive.js
@@ -45,8 +45,30 @@ gviz.column_style.ColumnStyleDirective = function() {
       'widgetConfig': '='
     },
     templateUrl: '/static/components/widget/data_viz/gviz/column_style/column-style-directive.html',
-    controller: ['$scope', 'columnStyleService', 'arrayUtilService', function(
-        $scope, columnStyleService, arrayUtilService) {
+    controller: ['$scope', 'columnStyleService', 'arrayUtilService', 'dashboardService',
+        function($scope, columnStyleService, arrayUtilService, dashboardService) {
+
+      /**
+       * Watches for changes to the column id, and refreshes the widget if a match is made.
+       */
+      $scope.$watch('ngModel.column_id', (newVal, oldVal) => {
+        let dataTable = $scope.widgetConfig.state().datasource.data;
+        if (newVal !== oldVal &&
+            !goog.string.isEmptySafe(newVal) &&
+            goog.isDefAndNotNull(dataTable)) {
+          let columnId = columnStyleService.getColumnIndex(newVal, dataTable);
+
+          if (columnId !== -1) {
+            dashboardService.refreshWidget($scope.widgetConfig);
+          } else if (!goog.string.isEmptySafe(oldVal)) {
+            columnId = columnStyleService.getColumnIndex(oldVal, dataTable);
+
+            if (columnId !== -1) {
+              dashboardService.refreshWidget($scope.widgetConfig);
+            }
+          }
+        }
+      });
 
       /**
        * Returns true if the column provided by ngModel is selected, otherwise false.

--- a/client/components/widget/data_viz/gviz/column_style/column-style-directive.js
+++ b/client/components/widget/data_viz/gviz/column_style/column-style-directive.js
@@ -52,18 +52,32 @@ gviz.column_style.ColumnStyleDirective = function() {
        * Watches for changes to the column id, and refreshes the widget if a match is made.
        */
       $scope.$watch('ngModel.column_id', (newVal, oldVal) => {
+        let columnIndex;
         let dataTable = $scope.widgetConfig.state().datasource.data;
-        if (newVal !== oldVal &&
-            !goog.string.isEmptySafe(newVal) &&
-            goog.isDefAndNotNull(dataTable)) {
-          let columnId = columnStyleService.getColumnIndex(newVal, dataTable);
 
-          if (columnId !== -1) {
-            dashboardService.refreshWidget($scope.widgetConfig);
-          } else if (!goog.string.isEmptySafe(oldVal)) {
-            columnId = columnStyleService.getColumnIndex(oldVal, dataTable);
+        if (newVal !== oldVal && goog.isDefAndNotNull(dataTable)) {
+          let shouldRefresh = false;
 
-            if (columnId !== -1) {
+          try {
+            if (!goog.string.isEmptySafe(newVal)) {
+              columnIndex = columnStyleService.getColumnIndex(newVal, dataTable);
+
+              if (columnIndex !== -1) {
+                shouldRefresh = true;
+              }
+            }
+
+            if (!goog.string.isEmptySafe(oldVal)) {
+              columnIndex = columnStyleService.getColumnIndex(oldVal, dataTable);
+
+              if (columnIndex !== -1) {
+                dataTable.setColumnLabel(columnIndex, oldVal);
+                dataTable.setColumnProperty(columnIndex, 'role', '');
+                shouldRefresh = true;
+              }
+            }
+          } finally {
+            if (shouldRefresh) {
               dashboardService.refreshWidget($scope.widgetConfig);
             }
           }

--- a/client/components/widget/data_viz/gviz/column_style/column-style-directive.js
+++ b/client/components/widget/data_viz/gviz/column_style/column-style-directive.js
@@ -32,8 +32,7 @@ const gviz = explorer.components.widget.data_viz.gviz;
  * @return {Object} Directive definition object.
  * @ngInject
  */
-gviz.column_style.ColumnStyleDirective = function(
-    queryEditorService) {
+gviz.column_style.ColumnStyleDirective = function() {
   return {
     restrict: 'E',
     replace: true,
@@ -41,7 +40,9 @@ gviz.column_style.ColumnStyleDirective = function(
     scope: {
       /** @type {!ColumnStyleModel} */
       'ngModel': '=',
-      'widgetModel': '='
+
+      /** @type {!ChartWidgetConfig} */
+      'widgetConfig': '='
     },
     templateUrl: '/static/components/widget/data_viz/gviz/column_style/column-style-directive.html',
     controller: ['$scope', 'columnStyleService', 'arrayUtilService', function(
@@ -59,7 +60,7 @@ gviz.column_style.ColumnStyleDirective = function(
        * Removes the column provided by ngModel from the widget config.
        */
       $scope.remove = function() {
-        columnStyleService.removeColumn($scope.widgetModel, $scope.ngModel);
+        columnStyleService.removeColumn($scope.widgetConfig, $scope.ngModel);
       }
 
       /**

--- a/client/components/widget/data_viz/gviz/column_style/column-style-directive_test.js
+++ b/client/components/widget/data_viz/gviz/column_style/column-style-directive_test.js
@@ -28,7 +28,7 @@ describe('ColumnStyleDirective', function() {
   // declare these up here to be global to all tests
   var scope, $compile, $timeout, $httpBackend, uiConfig;
   var configService, columnStyleService, dashboardService, GvizDataTable;
-  var providedDataTable;
+  var providedDataTable, providedData;
 
   const explorer = p3rf.perfkit.explorer;
   const ColumnStyleModel = explorer.components.widget.data_viz.gviz.column_style.ColumnStyleModel;
@@ -150,8 +150,6 @@ describe('ColumnStyleDirective', function() {
   });
 
   describe('should refresh the widget when the column id changes', function() {
-    var providedData;
-
     beforeEach(inject(function() {
       scope.providedWidget.state().datasource.data = providedDataTable;
     }));

--- a/client/components/widget/data_viz/gviz/column_style/column-style-directive_test.js
+++ b/client/components/widget/data_viz/gviz/column_style/column-style-directive_test.js
@@ -1,0 +1,133 @@
+/**
+ * @copyright Copyright 2015 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @fileoverview Tests for ColumnStyleDirective, which provides UX for managing
+ * column formatting, roles and titles.
+ * @author joemu@google.com (Joe Allan Muharsky)
+ */
+
+goog.require('p3rf.perfkit.explorer.components.config.ConfigService');
+goog.require('p3rf.perfkit.explorer.components.dashboard.DashboardService');
+goog.require('p3rf.perfkit.explorer.components.widget.data_viz.gviz.column_style.ColumnStyleDirective');
+goog.require('p3rf.perfkit.explorer.components.widget.data_viz.gviz.column_style.ColumnStyleModel');
+
+
+describe('ColumnStyleDirective', function() {
+  // declare these up here to be global to all tests
+  var scope, $compile, $timeout, $httpBackend, uiConfig;
+  var configService, columnStyleService, dashboardService;
+
+  const explorer = p3rf.perfkit.explorer;
+  const ColumnStyleModel = explorer.components.widget.data_viz.gviz.column_style.ColumnStyleModel;
+
+  beforeEach(module('explorer'));
+  beforeEach(module('p3rf.perfkit.explorer.templates'));
+
+  beforeEach(inject(function(_$rootScope_, _$compile_, _$timeout_,
+      _$httpBackend_, _configService_, _dashboardService_,
+      _explorerService_, _columnStyleService_) {
+    $compile = _$compile_;
+    $httpBackend = _$httpBackend_;
+    $timeout = _$timeout_;
+
+    scope = _$rootScope_.$new();
+    scope.providedModel = new ColumnStyleModel();
+
+    configSvc = _configService_;
+    dashboardSvc = _dashboardService_;
+    columnStyleSvc = _columnStyleService_;
+    explorerSvc = _explorerService_;
+
+    explorerSvc.newDashboard();
+    scope.$digest();
+  }));
+
+  describe('compilation', function() {
+
+    it('should succeed as a standalone element.', function() {
+      function compile() {
+        var actualElement = angular.element(
+            '<column-style ng-model="providedWidgetModel" />');
+
+        $compile(actualElement)(scope);
+        scope.$digest();
+      }
+      expect(compile).not.toThrow();
+    });
+  });
+
+  describe('should contain a element for', function() {
+
+    var actualElement;
+
+    beforeEach(inject(function() {
+      actualElement = angular.element(
+        '<column-style ng-model="providedModel" />');
+
+      $compile(actualElement)(scope);
+      scope.$digest();
+    }));
+
+    it('the column id', function() {
+      var targetElement = actualElement.find(
+        'input.widget-column-style-id');
+      expect(targetElement.length).toBe(1);
+    });
+
+    it('the title', function() {
+      var targetElement = actualElement.find(
+        'input.widget-column-style-title');
+      expect(targetElement.length).toBe(1);
+    });
+  });
+
+  describe('should reflect the ngModel state for', function() {
+    var columns;
+
+    beforeEach(inject(function() {
+      actualElement = angular.element(
+        '<column-style ng-model="providedModel" />');
+
+      $compile(actualElement)(scope);
+      scope.$digest();
+    }));
+
+    it('the column id', function() {
+      var columnIdElement = actualElement.find(
+        'input.widget-column-style-id')[0];
+      var expectedId = 'COLUMN_ID';
+
+      expect(columnIdElement.value).toBe('');
+
+      scope.providedModel.column_id = expectedId;
+      scope.$digest();
+
+      expect(columnIdElement.value).toBe(expectedId);
+    });
+
+    it('the title', function() {
+      var columnTitleElement = actualElement.find(
+        'input.widget-column-style-title')[0];
+      var expectedTitle = 'TITLE';
+
+      expect(columnTitleElement.value).toBe('');
+
+      scope.providedModel.title = expectedTitle;
+      scope.$digest();
+
+      expect(columnTitleElement.value).toBe(expectedTitle);
+    });
+  });
+});

--- a/client/components/widget/data_viz/gviz/column_style/column-style-directive_test.js
+++ b/client/components/widget/data_viz/gviz/column_style/column-style-directive_test.js
@@ -204,4 +204,23 @@ describe('ColumnStyleDirective', function() {
           scope.providedWidget);
     });
   });
+
+  it('should restore the label and role when changing from a match', function() {
+    scope.providedModel.column_id = 'timestamp';
+    scope.providedModel.title = 'CHANGED';
+
+    actualElement = angular.element(
+      '<column-style ng-model="providedModel" widget-config="providedWidget" />');
+    $compile(actualElement)(scope);
+    scope.$digest();
+
+    spyOn(dashboardSvc, 'refreshWidget');
+
+    scope.providedModel.column_id = 'sales_amt';
+    scope.$digest();
+
+    var dataTable = scope.providedWidget.state().datasource.data;
+
+    expect(dataTable.getColumnLabel(0)).toEqual('timestamp');
+  });
 });

--- a/client/components/widget/data_viz/gviz/column_style/column-style-model.js
+++ b/client/components/widget/data_viz/gviz/column_style/column-style-model.js
@@ -1,0 +1,49 @@
+/**
+ * @copyright Copyright 2015 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @fileoverview columnStyleService is a model encapsulating the properties
+ * of a column style.  In practice, it is contained in a heterogenous array.
+ * @author joemu@google.com (Joe Allan Muharsky)
+ */
+
+goog.provide('p3rf.perfkit.explorer.components.widget.data_viz.gviz.column_style.ColumnStyleModel');
+
+
+goog.scope(function() {
+const explorer = p3rf.perfkit.explorer;
+const gviz = explorer.components.widget.data_viz.gviz;
+
+
+/**
+ * See module docstring for more information about purpose and usage.
+ *
+ * @export
+ */
+gviz.column_style.ColumnStyleModel = class {
+  constructor(columnId, title) {
+    /**
+     * Specifies the column id that the style applies to.
+     * @export {string}
+     */
+    this.column_id = columnId || '';
+
+    /**
+     * A string representing a real-world name for the column.
+     */
+    this.title = title || '';
+  }
+}
+
+});  // goog.scope

--- a/client/components/widget/data_viz/gviz/column_style/column-style-service.js
+++ b/client/components/widget/data_viz/gviz/column_style/column-style-service.js
@@ -200,13 +200,11 @@ gviz.column_style.ColumnStyleService = class {
       throw new Error('getColumnIndex failed: \'columnId\' is a required string.')
     }
 
-    if (!goog.isDefAndNotNull(dataTable)) {
-      throw new Error('getColumnIndex failed: \'dataTable\' is required.')
-    }
-
-    for (var i=0, len=dataTable.getNumberOfColumns(); i<len; ++i) {
-      if (dataTable.getColumnId(i) === columnId) {
-        return i;
+    if (goog.isDefAndNotNull(dataTable)) {
+      for (var i=0, len=dataTable.getNumberOfColumns(); i<len; ++i) {
+        if (dataTable.getColumnId(i) === columnId) {
+          return i;
+        }
       }
     }
 

--- a/client/components/widget/data_viz/gviz/column_style/column-style-service.js
+++ b/client/components/widget/data_viz/gviz/column_style/column-style-service.js
@@ -1,0 +1,198 @@
+/**
+ * @copyright Copyright 2015 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @fileoverview columnStyleService is an angular service used format
+ * DataTable, DataView and/or Chart config based on widget config.
+ * @author joemu@google.com (Joe Allan Muharsky)
+ */
+
+goog.provide('p3rf.perfkit.explorer.components.widget.data_viz.gviz.column_style.ColumnStyleService');
+
+goog.require('p3rf.perfkit.explorer.components.widget.data_viz.gviz.column_style.ColumnStyleModel');
+goog.require('p3rf.perfkit.explorer.components.error.ErrorTypes');
+
+
+goog.scope(function() {
+const explorer = p3rf.perfkit.explorer;
+const gviz = explorer.components.widget.data_viz.gviz;
+const ColumnStyleModel = gviz.column_style.ColumnStyleModel;
+const ErrorTypes = explorer.components.error.ErrorTypes;
+
+
+/**
+ * See module docstring for more information about purpose and usage.
+ *
+ * @export
+ * @ngInject
+ */
+gviz.column_style.ColumnStyleService = class {
+  constructor(errorService, arrayUtilService) {
+    /** @export {!ArrayUtilService} */
+    this.arrayUtilSvc = arrayUtilService;
+
+    /**
+     * Specifies the currently selected column in the UX.
+     * @export {?ColumnStyleModel}
+     */
+    this.selectedColumn = null;
+  }
+
+  /**
+   * Creates a new column and returns it.
+   * @return {!ColumnStyleModel}
+   * @export
+   */
+  newColumn() {
+    return new ColumnStyleModel();
+  }
+
+  /**
+   * Adds a new column and returns it.
+   * @return {!ColumnStyleModel}
+   * @export
+   */
+  addColumn(config) {
+    let newColumn = this.newColumn();
+
+    config.chart.columns.push(newColumn);
+
+    return newColumn;
+  }
+
+  /**
+   * Removes the provided column from the provided widget config.
+   * @param {!ChartWidgetModel} config
+   * @param {!ColumnStyleModel} column
+   * @export
+   */
+  removeColumn(config, column) {
+    if (this.selectedColumn == column) {
+      this.selectedColumn = null;
+    }
+
+    this.arrayUtilSvc.remove(config.chart.columns, column);
+  }
+
+  /**
+   * Adds any columns present in the dataTable but not already defined.
+   * @param {!ChartWidgetConfig} config
+   * @export
+   */
+  addColumnsFromDatasource(config) {
+    config.model.chart.columns = this.getEffectiveColumns(
+        config.model.chart.columns,
+        config.state().datasource.data);
+  }
+
+  /**
+   * Returns any explicitly-defined columns, followed by any additional
+   * columns present in the dataTable.
+   *
+   * @param {!Array.<ColumnStyleModel>} columns
+   * @param {!google.visualizations.DataTable} dataTable
+   * @return {!Array.<!ColumnStyleModel>}
+   * @export
+   */
+  getEffectiveColumns(columns, dataTable) {
+    let effectiveColumns = [];
+    let definedColumnStyles = {};
+    let columnIndex = null;
+
+    if (!goog.isDefAndNotNull(dataTable)) {
+      return columns;
+    }
+
+    columns.forEach(column => {
+      columnIndex = this.getColumnIndex(column.column_id, dataTable);
+
+      if (columnIndex === -1) {
+        errorService.addError(ErrorTypes.WARNING,
+            'applyToDataTable warning: column \'' + columnId + '\' could not be found.');
+      } else {
+        definedColumnStyles[column.column_id] = true;
+
+        effectiveColumns.push(column);
+      }
+    });
+
+    for (let i=0, len=dataTable.getNumberOfColumns(); i<len; ++i) {
+      let columnId = dataTable.getColumnId(i);
+
+      if (!definedColumnStyles[columnId]) {
+        effectiveColumns.push(new ColumnStyleModel(dataTable.getColumnId(i)));
+      }
+    }
+
+    return effectiveColumns;
+  }
+
+  /**
+   * Applies a list of column styles to the dataTable.  This includes setting
+   * the label for the column, as well as other properties in the future.
+   *
+   * @param {!Array.<ColumnStyleModel>} columns
+   * @param {!google.visualizations.DataTable} dataTable
+   * @export
+   */
+  applyToDataTable(columns, dataTable) {
+    if (!goog.isDefAndNotNull(columns)) {
+      throw new Error('applyToDataTable failed: \'columns\' is required.');
+    }
+
+    if (!goog.isDefAndNotNull(dataTable)) {
+      throw new Error('applyToDataTable failed: \'dataTable\' is required.');
+    }
+
+    let columnId;
+
+    columns.forEach(column => {
+      let columnIndex = this.getColumnIndex(column.column_id, dataTable);
+      goog.asserts.assert(columnIndex !== -1);
+
+      if (!goog.string.isEmptySafe(column.title)) {
+        dataTable.setColumnLabel(columnIndex, column.title);
+      } else {
+        dataTable.setColumnLabel(columnIndex, column.column_id);
+      }
+    });
+  }
+
+  /**
+   * Returns the index of the DataTable column matching the provided id.
+   * @param {string} columnId
+   * @param {!google.visualizations.DataTable} dataTable
+   * @return {number} The 0-based index of the column, or -1 if not found.
+   * @export
+   */
+  getColumnIndex(columnId, dataTable) {
+    if (!goog.isDefAndNotNull(columnId)) {
+      throw new Error('getColumnIndex failed: \'columnId\' is a required string.')
+    }
+
+    if (!goog.isDefAndNotNull(dataTable)) {
+      throw new Error('getColumnIndex failed: \'dataTable\' is required.')
+    }
+
+    for (var i=0, len=dataTable.getNumberOfColumns(); i<len; ++i) {
+      if (dataTable.getColumnId(i) === columnId) {
+        return i;
+      }
+    }
+
+    return -1;
+  }
+}
+
+});  // goog.scope

--- a/client/components/widget/data_viz/gviz/column_style/column-style-service.js
+++ b/client/components/widget/data_viz/gviz/column_style/column-style-service.js
@@ -38,9 +38,12 @@ const ErrorTypes = explorer.components.error.ErrorTypes;
  * @ngInject
  */
 gviz.column_style.ColumnStyleService = class {
-  constructor(errorService, arrayUtilService) {
+  constructor(errorService, arrayUtilService, dashboardService) {
     /** @export {!ArrayUtilService} */
     this.arrayUtilSvc = arrayUtilService;
+
+    /** @export {!DashboardService} */
+    this.dashboardSvc = dashboardService;
 
     /**
      * Specifies the currently selected column in the UX.
@@ -73,16 +76,18 @@ gviz.column_style.ColumnStyleService = class {
 
   /**
    * Removes the provided column from the provided widget config.
-   * @param {!ChartWidgetModel} config
+   * @param {!ChartWidgetConfig} widget
    * @param {!ColumnStyleModel} column
    * @export
    */
-  removeColumn(config, column) {
+  removeColumn(widget, column) {
     if (this.selectedColumn == column) {
       this.selectedColumn = null;
     }
 
-    this.arrayUtilSvc.remove(config.chart.columns, column);
+    this.arrayUtilSvc.remove(widget.movel.chart.columns, column);
+
+    this.dashboardSvc.refreshWidget(widget);
   }
 
   /**
@@ -192,6 +197,48 @@ gviz.column_style.ColumnStyleService = class {
     }
 
     return -1;
+  }
+
+  /**
+   * Moves the provided column to the previous position.
+   * @param {!ChartWidgetConfig} widget
+   * @param {!ColumnStyleModel} column
+   */
+  movePrevious(widget, column) {
+    if (!goog.isDefAndNotNull(widget)) {
+      throw new Error('movePrevious failed: \'widget\' is required.')
+    }
+
+    if (!goog.isDefAndNotNull(column)) {
+      throw new Error('movePrevious failed: \'column\' is required.')
+    }
+
+    this.arrayUtilSvc.movePrevious(
+      widget.model.chart.columns,
+      column);
+
+    this.dashboardSvc.refreshWidget(widget);
+  }
+
+  /**
+   * Moves the provided column to the next position.
+   * @param {!ChartWidgetConfig} widget
+   * @param {!ColumnStyleModel} column
+   */
+  moveNext(widget, column) {
+    if (!goog.isDefAndNotNull(widget)) {
+      throw new Error('moveNext failed: \'widget\' is required.')
+    }
+
+    if (!goog.isDefAndNotNull(column)) {
+      throw new Error('moveNext failed: \'column\' is required.')
+    }
+
+    this.arrayUtilSvc.moveNext(
+      widget.model.chart.columns,
+      column);
+
+    this.dashboardSvc.refreshWidget(widget);
   }
 }
 

--- a/client/components/widget/data_viz/gviz/column_style/column-style-service.js
+++ b/client/components/widget/data_viz/gviz/column_style/column-style-service.js
@@ -45,6 +45,9 @@ gviz.column_style.ColumnStyleService = class {
     /** @export {!DashboardService} */
     this.dashboardSvc = dashboardService;
 
+    /** @export {!ErrorService} */
+    this.errorSvc = errorService;
+
     /**
      * Specifies the currently selected column in the UX.
      * @export {?ColumnStyleModel}
@@ -132,8 +135,9 @@ gviz.column_style.ColumnStyleService = class {
       columnIndex = this.getColumnIndex(column.column_id, dataTable);
 
       if (columnIndex === -1) {
-        errorService.addError(ErrorTypes.WARNING,
-            'applyToDataTable warning: column \'' + columnId + '\' could not be found.');
+        this.errorSvc.addError(ErrorTypes.WARNING,
+            'applyToDataTable warning: column \'' + column.column_id +
+            '\' could not be found.');
       } else {
         definedColumnStyles[column.column_id] = true;
 
@@ -173,12 +177,13 @@ gviz.column_style.ColumnStyleService = class {
 
     columns.forEach(column => {
       let columnIndex = this.getColumnIndex(column.column_id, dataTable);
-      goog.asserts.assert(columnIndex !== -1);
 
-      if (!goog.string.isEmptySafe(column.title)) {
-        dataTable.setColumnLabel(columnIndex, column.title);
-      } else {
-        dataTable.setColumnLabel(columnIndex, column.column_id);
+      if (columnIndex !== -1) {
+        if (!goog.string.isEmptySafe(column.title)) {
+          dataTable.setColumnLabel(columnIndex, column.title);
+        } else {
+          dataTable.setColumnLabel(columnIndex, column.column_id);
+        }
       }
     });
   }

--- a/client/components/widget/data_viz/gviz/column_style/column-style-service.js
+++ b/client/components/widget/data_viz/gviz/column_style/column-style-service.js
@@ -85,20 +85,29 @@ gviz.column_style.ColumnStyleService = class {
       this.selectedColumn = null;
     }
 
-    this.arrayUtilSvc.remove(widget.movel.chart.columns, column);
+    this.arrayUtilSvc.remove(widget.model.chart.columns, column);
 
-    this.dashboardSvc.refreshWidget(widget);
+    // Revert the label back to the column id.
+    let dataTable = widget.state().datasource.data;
+    if (goog.isDefAndNotNull(dataTable)) {
+      let columnIndex = this.getColumnIndex(column.column_id, dataTable);
+
+      goog.asserts.assert(columnIndex !== -1);
+
+      dataTable.setColumnLabel(columnIndex, column.column_id);
+    }
   }
 
   /**
    * Adds any columns present in the dataTable but not already defined.
-   * @param {!ChartWidgetConfig} config
+   * @param {!ChartWidgetConfig} widget
    * @export
    */
-  addColumnsFromDatasource(config) {
-    config.model.chart.columns = this.getEffectiveColumns(
-        config.model.chart.columns,
-        config.state().datasource.data);
+  addColumnsFromDatasource(widget) {
+    widget.model.chart.columns = this.getEffectiveColumns(
+        widget.model.chart.columns,
+        widget.state().datasource.data);
+    this.dashboardSvc.refreshWidget(widget);
   }
 
   /**

--- a/client/components/widget/data_viz/gviz/column_style/column-style-service_test.js
+++ b/client/components/widget/data_viz/gviz/column_style/column-style-service_test.js
@@ -28,7 +28,7 @@ describe('columnStyleService', function() {
 
   var svc, providedDataTable, GvizDataTable, providedConfig,
       providedColumn1, providedColumn2;
-  var dashboardSvc, widgetFactorySvc;
+  var dashboardSvc, widgetFactorySvc, errorSvc;
 
   var ChartWidgetConfig = p3rf.perfkit.explorer.models.ChartWidgetConfig;
   var ColumnStyleModel = gviz.column_style.ColumnStyleModel;
@@ -37,11 +37,15 @@ describe('columnStyleService', function() {
   beforeEach(module('googleVisualizationMocks'));
 
   beforeEach(inject(function(
-      columnStyleService, _GvizDataTable_, _dashboardService_, _widgetFactoryService_) {
+      columnStyleService, _GvizDataTable_, _dashboardService_,
+      _widgetFactoryService_, _errorService_) {
     svc = columnStyleService;
     GvizDataTable = _GvizDataTable_;
     dashboardSvc = _dashboardService_;
     widgetFactorySvc = _widgetFactoryService_;
+    errorSvc = _errorService_;
+
+    errorSvc.logToConsole = false;
   }));
 
   beforeEach(function() {
@@ -115,6 +119,14 @@ describe('columnStyleService', function() {
       ];
       expect(actualColumns).toEqual(expectedColumns);
     });
+
+    it('should suppress an error when the column does not exist in the dataTable',
+        function() {
+      var expectedColumns = [new ColumnStyleModel('NOTFOUND')];
+      providedConfig.model.chart.columns = expectedColumns;
+      svc.getEffectiveColumns(
+          providedConfig.model.chart.columns, providedDataTable);
+    });
   });
 
   describe('addColumnsFromDatasource', function() {
@@ -141,6 +153,13 @@ describe('columnStyleService', function() {
 
       expect(providedDataTable.getColumnLabel(0)).toEqual('Quarter Ending');
       expect(providedDataTable.getColumnLabel(1)).toEqual('Total Sales');
+    });
+
+    it('should suppress an error when the column does not exist in the dataTable',
+        function() {
+      var expectedColumns = [new ColumnStyleModel('NOTFOUND')];
+      providedConfig.model.chart.columns = expectedColumns;
+      svc.applyToDataTable(providedConfig.model.chart.columns, providedDataTable);
     });
 
     describe('should throw an error with a missing/null parameter for', function() {

--- a/client/components/widget/data_viz/gviz/column_style/column-style-service_test.js
+++ b/client/components/widget/data_viz/gviz/column_style/column-style-service_test.js
@@ -207,15 +207,5 @@ describe('columnStyleService', function() {
         svc.getColumnIndex(null);
       }).toThrowError(expectedError);
     });
-
-    it('should raise an error if a dataTable is not provided', function() {
-      expect(function() {
-        svc.getColumnIndex('timestamp');
-      }).toThrowError('getColumnIndex failed: \'dataTable\' is required.');
-
-      expect(function() {
-        svc.getColumnIndex('timestamp', null);
-      }).toThrowError('getColumnIndex failed: \'dataTable\' is required.');
-    });
   })
 });

--- a/client/components/widget/data_viz/gviz/column_style/column-style-service_test.js
+++ b/client/components/widget/data_viz/gviz/column_style/column-style-service_test.js
@@ -1,0 +1,179 @@
+/**
+ * @copyright Copyright 2015 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @fileoverview Tests for the columnStyleService service.
+ * @author joemu@google.com (Joe Allan Muharsky)
+ */
+
+goog.require('p3rf.perfkit.explorer.application.module');
+goog.require('p3rf.perfkit.explorer.components.widget.data_viz.gviz.column_style.ColumnStyleModel');
+goog.require('p3rf.perfkit.explorer.components.widget.data_viz.gviz.column_style.ColumnStyleService');
+goog.provide('p3rf.perfkit.explorer.models.ChartWidgetModel');
+
+describe('columnStyleService', function() {
+  var explorer = p3rf.perfkit.explorer;
+  var gviz = explorer.components.widget.data_viz.gviz;
+
+  var svc, providedDataTable, GvizDataTable, providedConfig,
+      providedColumn1, providedColumn2;
+  var ChartWidgetModel = p3rf.perfkit.explorer.models.ChartWidgetModel;
+  var ColumnStyleModel = gviz.column_style.ColumnStyleModel;
+
+  beforeEach(module('explorer'));
+  beforeEach(module('googleVisualizationMocks'));
+
+  beforeEach(inject(function(columnStyleService, _GvizDataTable_) {
+    svc = columnStyleService;
+    GvizDataTable = _GvizDataTable_;
+  }));
+
+  beforeEach(function() {
+    providedConfig = new ChartWidgetModel();
+    providedColumn1 = new ColumnStyleModel('timestamp', 'Quarter Ending');
+    providedColumn2 = new ColumnStyleModel('sales_amt', 'Total Sales');
+    providedConfig.chart.columns.push(providedColumn1, providedColumn2);
+
+    var data = {
+      cols: [
+        {id: 'timestamp', type: 'date'},
+        {id: 'sales_amt', type: 'number'}
+      ],
+      rows: [
+        {c: [
+          {v: '2013/03/30'},
+          {v: 3}
+        ]}
+      ]
+    };
+
+    providedDataTable = new GvizDataTable(data);
+  });
+
+  describe('removeColumn', function() {
+
+    it('should remove the provided column from the provided widget', function() {
+      svc.removeColumn(providedConfig, providedColumn1);
+
+      expect(providedConfig.chart.columns).toEqual([providedColumn2]);
+    });
+  });
+
+  describe('getEffectiveColumns', function() {
+
+    it('should return column styles when none are explicitly defined', function() {
+      providedConfig.chart.columns = [];
+
+      var actualColumns = svc.getEffectiveColumns(
+          providedConfig.chart.columns, providedDataTable);
+      var expectedColumns = [
+        new ColumnStyleModel('timestamp'),
+        new ColumnStyleModel('sales_amt')
+      ];
+
+      expect(actualColumns).toEqual(expectedColumns);
+    });
+
+    it('should apply column styles when defined', function() {
+      var providedColumns = [
+        new ColumnStyleModel('timestamp', 'Date'),
+        new ColumnStyleModel('sales_amt', 'Sales')
+      ];
+      providedConfig.chart.columns = providedColumns;
+
+      var actualColumns = svc.getEffectiveColumns(
+          providedConfig.chart.columns, providedDataTable);
+
+      expect(actualColumns).toEqual(providedColumns);
+    });
+
+    it('should append columns without explicit definition at the end', function() {
+      providedConfig.chart.columns = [new ColumnStyleModel('timestamp', 'Date')];
+
+      var actualColumns = svc.getEffectiveColumns(
+          providedConfig.chart.columns, providedDataTable);
+      var expectedColumns = [
+        new ColumnStyleModel('timestamp', 'Date'),
+        new ColumnStyleModel('sales_amt')
+      ];
+      expect(actualColumns).toEqual(expectedColumns);
+    });
+  });
+
+  describe('applyToDataTable', function() {
+
+    it('should replace column titles', function() {
+      svc.applyToDataTable(providedConfig.chart.columns, providedDataTable);
+
+      expect(providedDataTable.getColumnLabel(0)).toEqual('Quarter Ending');
+      expect(providedDataTable.getColumnLabel(1)).toEqual('Total Sales');
+    });
+
+    describe('should throw an error with a missing/null parameter for', function() {
+      it('columns', function() {
+        var expectedError = 'applyToDataTable failed: \'columns\' is required.';
+
+        expect(svc.applyToDataTable).toThrowError(expectedError);
+
+        expect(function() {
+          svc.applyToDataTable(null);
+        }).toThrowError(expectedError);
+      });
+
+      it('dataTable', function() {
+        var expectedError = 'applyToDataTable failed: \'dataTable\' is required.';
+
+        expect(function() {
+          svc.applyToDataTable(providedConfig.chart.columns);
+        }).toThrowError(expectedError);
+
+        expect(function() {
+          svc.applyToDataTable(providedConfig.chart.columns, null);
+        }).toThrowError(expectedError);
+      });
+    });
+  });
+
+  describe('getColumnIndex', function() {
+
+    it('should return the index of a matching column name', function() {
+      expect(svc.getColumnIndex('timestamp', providedDataTable)).toEqual(0);
+      expect(svc.getColumnIndex('sales_amt', providedDataTable)).toEqual(1);
+    });
+
+    it('should return -1 if the column is not found', function() {
+      expect(svc.getColumnIndex('UNDEFINED', providedDataTable)).toEqual(-1);
+    });
+
+    it('should raise an error if a column string is not provided', function() {
+      var expectedError = 'getColumnIndex failed: \'columnId\' is a required string.';
+
+      expect(svc.getColumnIndex).toThrowError(expectedError);
+
+      expect(function() {
+        svc.getColumnIndex(null);
+      }).toThrowError(expectedError);
+    });
+
+    it('should raise an error if a dataTable is not provided', function() {
+      expect(function() {
+        svc.getColumnIndex('timestamp');
+      }).toThrowError('getColumnIndex failed: \'dataTable\' is required.');
+
+      expect(function() {
+        svc.getColumnIndex('timestamp', null);
+      }).toThrowError('getColumnIndex failed: \'dataTable\' is required.');
+    });
+  })
+});

--- a/client/components/widget/data_viz/gviz/column_style/column-style-toolbar-directive.html
+++ b/client/components/widget/data_viz/gviz/column_style/column-style-toolbar-directive.html
@@ -1,4 +1,8 @@
 <div>
+  <button type="button" class="btn btn-default widget-refresh"
+          ng-click="ctrl.dashboardSvc.refreshWidget(ngModel)">
+    Refresh
+  </button>
   <button type="button"
           class="btn btn-default dropdown-toggle column-add">
     Insert
@@ -6,6 +10,7 @@
   </button>
   <ul class="dropdown-menu column-add-dropdown">
     <li class="columns-add-datasource"
+        ng-disabled="!ngModel.state().datasource.data"
         ng-click="ctrl.columnStyleSvc.addColumnsFromDatasource(ngModel)">
         <a>from datasource</a>
     </li>
@@ -17,7 +22,7 @@
         <a>top</a>
     </li>
     <li class="column-add-before"
-        ng-show="ctrl.columnStyleSvc.selectedColumn"
+        ng-disabled="!ctrl.columnStyleSvc.selectedColumn"
         ng-click="ctrl.arrayUtilSvc.insertBefore(
             ngModel.model.chart.columns,
             ctrl.columnStyleSvc.newColumn(),
@@ -25,7 +30,7 @@
         <a>before</a>
     </li>
     <li class="column-add-after"
-        ng-show="ctrl.columnStyleSvc.selectedColumn"
+        ng-disabled="!ctrl.columnStyleSvc.selectedColumn"
         ng-click="ctrl.arrayUtilSvc.insertAfter(
             ngModel.model.chart.columns,
             ctrl.columnStyleSvc.newColumn(),

--- a/client/components/widget/data_viz/gviz/column_style/column-style-toolbar-directive.html
+++ b/client/components/widget/data_viz/gviz/column_style/column-style-toolbar-directive.html
@@ -1,45 +1,59 @@
 <div>
-  <button type="button" class="btn btn-default widget-refresh"
-          ng-click="ctrl.dashboardSvc.refreshWidget(ngModel)">
-    Refresh
-  </button>
   <button type="button"
           class="btn btn-default dropdown-toggle column-add">
     Insert
     <span class="caret"></span>
+    <md-tooltip md-direction="top">
+      Adds one or more <b>Column Styles</b> <i>(click to see options)</i>
+    </md-tooltip>
   </button>
   <ul class="dropdown-menu column-add-dropdown">
     <li class="columns-add-datasource"
-        ng-disabled="!ngModel.state().datasource.data"
+        ng-show="ngModel.state().datasource.data"
         ng-click="ctrl.columnStyleSvc.addColumnsFromDatasource(ngModel)">
-        <a>from datasource</a>
+      <a>from datasource</a>
+      <md-tooltip md-direction="right">
+        Adds a <b>Column Style</b> for each field in your selected widget's <b>Query</b>
+      </md-tooltip>
     </li>
     <li class="column-add-top"
         ng-click="ctrl.arrayUtilSvc.insertAt(
             ngModel.model.chart.columns,
             ctrl.columnStyleSvc.newColumn(),
             0)">
-        <a>top</a>
+      <a>top</a>
+      <md-tooltip md-direction="right">
+        Adds a <b>Column Style</b> at the top of the list
+      </md-tooltip>
     </li>
     <li class="column-add-before"
-        ng-disabled="!ctrl.columnStyleSvc.selectedColumn"
+        ng-show="ctrl.columnStyleSvc.selectedColumn"
         ng-click="ctrl.arrayUtilSvc.insertBefore(
             ngModel.model.chart.columns,
             ctrl.columnStyleSvc.newColumn(),
             ctrl.columnStyleSvc.selectedColumn)">
-        <a>before</a>
+      <a>before</a>
+      <md-tooltip md-direction="right">
+        Adds a <b>Column Style</b> at the bottom of the list
+      </md-tooltip>
     </li>
     <li class="column-add-after"
-        ng-disabled="!ctrl.columnStyleSvc.selectedColumn"
+        ng-show="ctrl.columnStyleSvc.selectedColumn"
         ng-click="ctrl.arrayUtilSvc.insertAfter(
             ngModel.model.chart.columns,
             ctrl.columnStyleSvc.newColumn(),
             ctrl.columnStyleSvc.selectedColumn)">
       <a>after</a>
+      <md-tooltip md-direction="right">
+        Adds a <b>Column Style</b> after the selected column
+      </md-tooltip>
     </li>
     <li class="column-add-bottom"
         ng-click="ctrl.columnStyleSvc.addColumn(ngModel.model)">
       <a>bottom</a>
+      <md-tooltip md-direction="right">
+        Adds a <b>Column Style</b> before the selected column
+      </md-tooltip>
     </li>
   </ul>
   <button type="button" class="btn btn-default column-move-up"
@@ -47,15 +61,26 @@
           ng-click="ctrl.columnStyleSvc.movePrevious(
               ngModel, ctrl.columnStyleSvc.selectedColumn)">
     <span class="glyphicon glyphicon-arrow-up"></span>
+    <md-tooltip md-direction="top">
+      Moves the <b>Column Style</b> to the previous position in the list
+    </md-tooltip>
   </button>
   <button type="button" class="btn btn-default column-move-down"
           ng-disabled="!ctrl.columnStyleSvc.selectedColumn"
           ng-click="ctrl.columnStyleSvc.moveNext(
               ngModel, ctrl.columnStyleSvc.selectedColumn)">
     <span class="glyphicon glyphicon-arrow-down"></span>
+    <md-tooltip md-direction="top">
+      Moves the <b>Column Style</b> to the next position in the list
+    </md-tooltip>
   </button>
   <button type="button" class="btn btn-default column-remove"
           ng-disabled="!ctrl.columnStyleSvc.selectedColumn"
           ng-click="ctrl.columnStyleSvc.removeColumn(
-              ngModel, ctrl.columnStyleSvc.selectedColumn)">Delete</button>
+              ngModel, ctrl.columnStyleSvc.selectedColumn)">
+    Remove
+    <md-tooltip md-direction="top">
+      Removes the <b>Column Style</b> from the list
+    </md-tooltip>
+  </button>
 </div>

--- a/client/components/widget/data_viz/gviz/column_style/column-style-toolbar-directive.html
+++ b/client/components/widget/data_viz/gviz/column_style/column-style-toolbar-directive.html
@@ -44,20 +44,18 @@
   </ul>
   <button type="button" class="btn btn-default column-move-up"
           ng-disabled="!ctrl.columnStyleSvc.selectedColumn"
-          ng-click="ctrl.arrayUtilSvc.movePrevious(
-              ngModel.model.chart.columns,
-              ctrl.columnStyleSvc.selectedColumn)">
+          ng-click="ctrl.columnStyleSvc.movePrevious(
+              ngModel, ctrl.columnStyleSvc.selectedColumn)">
     <span class="glyphicon glyphicon-arrow-up"></span>
   </button>
   <button type="button" class="btn btn-default column-move-down"
           ng-disabled="!ctrl.columnStyleSvc.selectedColumn"
-          ng-click="ctrl.arrayUtilSvc.moveNext(
-              ngModel.model.chart.columns,
-              ctrl.columnStyleSvc.selectedColumn)">
+          ng-click="ctrl.columnStyleSvc.moveNext(
+              ngModel, ctrl.columnStyleSvc.selectedColumn)">
     <span class="glyphicon glyphicon-arrow-down"></span>
   </button>
   <button type="button" class="btn btn-default column-remove"
           ng-disabled="!ctrl.columnStyleSvc.selectedColumn"
           ng-click="ctrl.columnStyleSvc.removeColumn(
-              ngModel.model, ctrl.columnStyleSvc.selectedColumn)">Delete</button>
+              ngModel, ctrl.columnStyleSvc.selectedColumn)">Delete</button>
 </div>

--- a/client/components/widget/data_viz/gviz/column_style/column-style-toolbar-directive.html
+++ b/client/components/widget/data_viz/gviz/column_style/column-style-toolbar-directive.html
@@ -1,0 +1,58 @@
+<div>
+  <button type="button"
+          class="btn btn-default dropdown-toggle column-add">
+    Insert
+    <span class="caret"></span>
+  </button>
+  <ul class="dropdown-menu column-add-dropdown">
+    <li class="columns-add-datasource"
+        ng-click="ctrl.columnStyleSvc.addColumnsFromDatasource(ngModel)">
+        <a>from datasource</a>
+    </li>
+    <li class="column-add-top"
+        ng-click="ctrl.arrayUtilSvc.insertAt(
+            ngModel.model.chart.columns,
+            ctrl.columnStyleSvc.newColumn(),
+            0)">
+        <a>top</a>
+    </li>
+    <li class="column-add-before"
+        ng-show="ctrl.columnStyleSvc.selectedColumn"
+        ng-click="ctrl.arrayUtilSvc.insertBefore(
+            ngModel.model.chart.columns,
+            ctrl.columnStyleSvc.newColumn(),
+            ctrl.columnStyleSvc.selectedColumn)">
+        <a>before</a>
+    </li>
+    <li class="column-add-after"
+        ng-show="ctrl.columnStyleSvc.selectedColumn"
+        ng-click="ctrl.arrayUtilSvc.insertAfter(
+            ngModel.model.chart.columns,
+            ctrl.columnStyleSvc.newColumn(),
+            ctrl.columnStyleSvc.selectedColumn)">
+      <a>after</a>
+    </li>
+    <li class="column-add-bottom"
+        ng-click="ctrl.columnStyleSvc.addColumn(ngModel.model)">
+      <a>bottom</a>
+    </li>
+  </ul>
+  <button type="button" class="btn btn-default column-move-up"
+          ng-disabled="!ctrl.columnStyleSvc.selectedColumn"
+          ng-click="ctrl.arrayUtilSvc.movePrevious(
+              ngModel.model.chart.columns,
+              ctrl.columnStyleSvc.selectedColumn)">
+    <span class="glyphicon glyphicon-arrow-up"></span>
+  </button>
+  <button type="button" class="btn btn-default column-move-down"
+          ng-disabled="!ctrl.columnStyleSvc.selectedColumn"
+          ng-click="ctrl.arrayUtilSvc.moveNext(
+              ngModel.model.chart.columns,
+              ctrl.columnStyleSvc.selectedColumn)">
+    <span class="glyphicon glyphicon-arrow-down"></span>
+  </button>
+  <button type="button" class="btn btn-default column-remove"
+          ng-disabled="!ctrl.columnStyleSvc.selectedColumn"
+          ng-click="ctrl.columnStyleSvc.removeColumn(
+              ngModel.model, ctrl.columnStyleSvc.selectedColumn)">Delete</button>
+</div>

--- a/client/components/widget/data_viz/gviz/column_style/column-style-toolbar-directive.js
+++ b/client/components/widget/data_viz/gviz/column_style/column-style-toolbar-directive.js
@@ -1,0 +1,55 @@
+/**
+ * @copyright Copyright 2015 Google Inc. All rights reserved.
+ *
+ * Use of this source code is governed by a BSD-style
+ * license that can be found in the LICENSE file or at
+ * https://developers.google.com/open-source/licenses/bsd
+ *
+ * @fileoverview ColumnStyleToolbarDirective encapsulates layout and UX
+ * for the Column Style toolbar.
+ *
+ * @author joemu@google.com (Joe Allan Muharsky)
+ */
+
+goog.provide('p3rf.perfkit.explorer.components.widget.data_viz.gviz.column_style.ColumnStyleToolbarDirective');
+
+goog.require('p3rf.perfkit.explorer.components.widget.data_viz.gviz.column_style.ColumnStyleService');
+
+
+goog.scope(function() {
+  const explorer = p3rf.perfkit.explorer;
+  const gviz = explorer.components.widget.data_viz.gviz;
+
+
+  /**
+   * See module docstring for more information about purpose and usage.
+   *
+   * @return {!Object} Directive definition object.
+   * @ngInject
+   */
+  gviz.column_style.ColumnStyleToolbarDirective = function(
+      columnStyleService, arrayUtilService) {
+    return {
+      restrict: 'E',
+      replace: true,
+      scope: {
+        /** @type {!ChartWidgetConfig} */
+        ngModel: '='
+      },
+      transclude: false,
+      templateUrl: '/static/components/widget/data_viz/gviz/column_style/column-style-toolbar-directive.html',
+      controller: ['$scope', function($scope) {
+        /** @type {!ArrayUtilService} */
+        this.arrayUtilSvc = arrayUtilService;
+
+        /** @type {!ColumnStyleService} */
+        this.columnStyleSvc = columnStyleService;
+
+        /** @type {!DashboardService} */
+        this.dashboardSvc = dashboardService;
+      }],
+      controllerAs: 'ctrl'
+    };
+  };
+
+});  // goog.scope

--- a/client/components/widget/data_viz/gviz/column_style/column-style-toolbar-directive.js
+++ b/client/components/widget/data_viz/gviz/column_style/column-style-toolbar-directive.js
@@ -28,7 +28,7 @@ goog.scope(function() {
    * @ngInject
    */
   gviz.column_style.ColumnStyleToolbarDirective = function(
-      columnStyleService, arrayUtilService) {
+      arrayUtilService, columnStyleService, dashboardService) {
     return {
       restrict: 'E',
       replace: true,

--- a/client/components/widget/data_viz/gviz/column_style/column-style-toolbar-directive_test.js
+++ b/client/components/widget/data_viz/gviz/column_style/column-style-toolbar-directive_test.js
@@ -1,0 +1,182 @@
+/**
+ * @copyright Copyright 2015 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @fileoverview Tests for ColumnStyleToolbarDirective, which encapsulates the
+ * state for the container toolbar.
+ * @author joemu@google.com (Joe Allan Muharsky)
+ */
+
+goog.require('p3rf.perfkit.explorer.components.util.ArrayUtilService');
+goog.require('p3rf.perfkit.explorer.components.widget.data_viz.gviz.column_style.ColumnStyleModel');
+goog.require('p3rf.perfkit.explorer.components.widget.data_viz.gviz.column_style.ColumnStyleToolbarDirective');
+goog.require('p3rf.perfkit.explorer.models.ChartWidgetConfig');
+
+
+describe('ColumnStyleToolbarDirective', function() {
+  var scope, $compile, $timeout, uiConfig;
+  var arrayUtilService, columnStyleService, widgetFactoryService;
+  var providedColumn;
+
+  const explorer = p3rf.perfkit.explorer;
+  const ChartWidgetConfig = explorer.models.ChartWidgetConfig;
+  const ColumnStyleModel = explorer.components.widget.data_viz.gviz.column_style.ColumnStyleModel;
+
+  beforeEach(module('explorer'));
+  beforeEach(module('p3rf.perfkit.explorer.templates'));
+
+  beforeEach(inject(function(
+      _$rootScope_, _$compile_, _$timeout_,
+      _arrayUtilService_, _columnStyleService_, _widgetFactoryService_) {
+    scope = _$rootScope_.$new();
+    $compile = _$compile_;
+    $timeout = _$timeout_;
+
+    arrayUtilService = _arrayUtilService_;
+    columnStyleService = _columnStyleService_;
+    widgetFactoryService = _widgetFactoryService_;
+
+    scope.widgetConfig = new ChartWidgetConfig(widgetFactoryService);
+    providedColumn = columnStyleService.addColumn(scope.widgetConfig.model);
+  }));
+
+  describe('compilation', function() {
+
+    it('should succeed as a standalone element.', function() {
+      function compile() {
+        var directiveElement = angular.element(
+            '<column-style-toolbar ng-model="widgetConfig" />');
+
+        $compile(directiveElement)(scope);
+        scope.$digest();
+      }
+      expect(compile).not.toThrow();
+    });
+  });
+
+  describe('should contain an element to', function() {
+    var actualElement, actualController;
+
+    beforeEach(inject(function() {
+      actualElement = angular.element('<column-style-toolbar ng-model="widgetConfig" />');
+      $compile(actualElement)(scope);
+
+      scope.$digest();
+
+      actualController = actualElement.controller('columnStyleToolbar');
+    }));
+
+    it('show the add column dropdown button', function() {
+      var targetElement = actualElement.find(
+          'button.column-add');
+      expect(targetElement.length).toBe(1);
+    });
+
+    it('list the add column options', function() {
+      var targetElement = actualElement.find(
+          'ul.column-add-dropdown');
+      expect(targetElement.length).toBe(1);
+    });
+
+    it('add a column at the top', function() {
+      var targetElement = actualElement.find(
+          'li.column-add-top');
+      expect(targetElement.length).toBe(1);
+
+      spyOn(arrayUtilService, 'insertAt');
+      targetElement.click();
+      expect(arrayUtilService.insertAt).toHaveBeenCalledWith(
+          scope.widgetConfig.model.chart.columns, new ColumnStyleModel(), 0);
+    });
+
+    it('add a column before the selected one', function() {
+      var targetElement = actualElement.find(
+          'li.column-add-before');
+      expect(targetElement.length).toBe(1);
+      columnStyleService.selectedColumn = providedColumn;
+
+      spyOn(arrayUtilService, 'insertBefore');
+      targetElement.click();
+      expect(arrayUtilService.insertBefore).toHaveBeenCalledWith(
+          scope.widgetConfig.model.chart.columns,
+          new ColumnStyleModel(),
+          columnStyleService.selectedColumn);
+    });
+
+    it('add a column after the selected one', function() {
+      var targetElement = actualElement.find(
+          'li.column-add-after');
+      expect(targetElement.length).toBe(1);
+      columnStyleService.selectedColumn = providedColumn;
+
+      spyOn(arrayUtilService, 'insertAfter');
+      targetElement.click();
+      expect(arrayUtilService.insertAfter).toHaveBeenCalledWith(
+          scope.widgetConfig.model.chart.columns,
+          new ColumnStyleModel(),
+          columnStyleService.selectedColumn);
+    });
+
+    it('add a column at the bottom', function() {
+      var targetElement = actualElement.find(
+          'li.column-add-bottom');
+      expect(targetElement.length).toBe(1);
+      columnStyleService.selectedColumn = providedColumn;
+
+      spyOn(columnStyleService, 'addColumn');
+      targetElement.click();
+      expect(columnStyleService.addColumn).toHaveBeenCalledWith(
+          scope.widgetConfig.model);
+    });
+
+    it('move the selected column up', function() {
+      var targetElement = actualElement.find(
+          'button.column-move-up');
+      expect(targetElement.length).toBe(1);
+      columnStyleService.selectedColumn = providedColumn;
+
+      spyOn(arrayUtilService, 'movePrevious');
+      targetElement.click();
+      expect(arrayUtilService.movePrevious).toHaveBeenCalledWith(
+          scope.widgetConfig.model.chart.columns,
+          providedColumn);
+    });
+
+    it('move the selected column down', function() {
+      var targetElement = actualElement.find(
+          'button.column-move-down');
+      expect(targetElement.length).toBe(1);
+      columnStyleService.selectedColumn = providedColumn;
+
+      spyOn(arrayUtilService, 'moveNext');
+      targetElement.click();
+      expect(arrayUtilService.moveNext).toHaveBeenCalledWith(
+          scope.widgetConfig.model.chart.columns,
+          providedColumn);
+    });
+
+    it('remove the selected column', function() {
+      var targetElement = actualElement.find(
+          'button.column-remove');
+      expect(targetElement.length).toBe(1);
+      columnStyleService.selectedColumn = providedColumn;
+
+      spyOn(columnStyleService, 'removeColumn');
+      targetElement.click();
+      expect(columnStyleService.removeColumn).toHaveBeenCalledWith(
+          scope.widgetConfig.model, providedColumn);
+    });
+
+  });
+});

--- a/client/components/widget/data_viz/gviz/column_style/column-style-toolbar-directive_test.js
+++ b/client/components/widget/data_viz/gviz/column_style/column-style-toolbar-directive_test.js
@@ -26,7 +26,7 @@ goog.require('p3rf.perfkit.explorer.models.ChartWidgetConfig');
 
 describe('ColumnStyleToolbarDirective', function() {
   var scope, $compile, $timeout, uiConfig;
-  var arrayUtilService, columnStyleService, widgetFactoryService;
+  var arrayUtilService, columnStyleService, dashboardService, widgetFactoryService;
   var providedColumn;
 
   const explorer = p3rf.perfkit.explorer;
@@ -38,13 +38,15 @@ describe('ColumnStyleToolbarDirective', function() {
 
   beforeEach(inject(function(
       _$rootScope_, _$compile_, _$timeout_,
-      _arrayUtilService_, _columnStyleService_, _widgetFactoryService_) {
+      _arrayUtilService_, _columnStyleService_, _dashboardService_,
+      _widgetFactoryService_) {
     scope = _$rootScope_.$new();
     $compile = _$compile_;
     $timeout = _$timeout_;
 
     arrayUtilService = _arrayUtilService_;
     columnStyleService = _columnStyleService_;
+    dashboardService = _dashboardService_;
     widgetFactoryService = _widgetFactoryService_;
 
     scope.widgetConfig = new ChartWidgetConfig(widgetFactoryService);
@@ -147,10 +149,15 @@ describe('ColumnStyleToolbarDirective', function() {
       columnStyleService.selectedColumn = providedColumn;
 
       spyOn(arrayUtilService, 'movePrevious');
+      spyOn(dashboardService, 'refreshWidget');
+
       targetElement.click();
+
       expect(arrayUtilService.movePrevious).toHaveBeenCalledWith(
           scope.widgetConfig.model.chart.columns,
           providedColumn);
+      expect(dashboardService.refreshWidget).toHaveBeenCalledWith(
+          scope.widgetConfig);
     });
 
     it('move the selected column down', function() {
@@ -160,10 +167,15 @@ describe('ColumnStyleToolbarDirective', function() {
       columnStyleService.selectedColumn = providedColumn;
 
       spyOn(arrayUtilService, 'moveNext');
+      spyOn(dashboardService, 'refreshWidget');
+
       targetElement.click();
+
       expect(arrayUtilService.moveNext).toHaveBeenCalledWith(
           scope.widgetConfig.model.chart.columns,
           providedColumn);
+      expect(dashboardService.refreshWidget).toHaveBeenCalledWith(
+          scope.widgetConfig);
     });
 
     it('remove the selected column', function() {
@@ -175,7 +187,7 @@ describe('ColumnStyleToolbarDirective', function() {
       spyOn(columnStyleService, 'removeColumn');
       targetElement.click();
       expect(columnStyleService.removeColumn).toHaveBeenCalledWith(
-          scope.widgetConfig.model, providedColumn);
+          scope.widgetConfig, providedColumn);
     });
 
   });

--- a/client/components/widget/data_viz/gviz/gviz-directive.js
+++ b/client/components/widget/data_viz/gviz/gviz-directive.js
@@ -73,7 +73,7 @@ const ResultsDataStatus = explorer.models.ResultsDataStatus;
 explorer.components.widget.data_viz.gviz.gvizChart = function(
     $timeout, $location, chartWrapperService, queryResultDataService,
     queryBuilderService, gvizEvents, dataViewService, dashboardService,
-    errorService) {
+    errorService, columnStyleService) {
   return {
     restrict: 'E',
     replace: true,

--- a/client/components/widget/data_viz/gviz/gviz-directive.js
+++ b/client/components/widget/data_viz/gviz/gviz-directive.js
@@ -32,6 +32,7 @@ goog.provide('p3rf.perfkit.explorer.components.widget.data_viz.gviz.gvizChart');
 
 goog.require('p3rf.perfkit.explorer.components.error.ErrorService');
 goog.require('p3rf.perfkit.explorer.components.error.ErrorTypes');
+goog.require('p3rf.perfkit.explorer.components.widget.data_viz.gviz.column_style.ColumnStyleService');
 goog.require('p3rf.perfkit.explorer.components.widget.data_viz.gviz.ChartWrapperService');
 goog.require('p3rf.perfkit.explorer.components.widget.data_viz.gviz.GvizEvents');
 goog.require('p3rf.perfkit.explorer.components.widget.data_viz.gviz.getGvizDataTable');
@@ -47,6 +48,8 @@ const explorer = p3rf.perfkit.explorer;
 const ChartType = explorer.models.ChartType;
 const ChartWrapperService = (
     explorer.components.widget.data_viz.gviz.ChartWrapperService);
+const ColumnStyleService = (
+    explorer.components.widget.data_viz.gviz.column_style.ColumnStyleService);
 const DataViewService = explorer.components.widget.query.DataViewService;
 const ErrorService = explorer.components.error.ErrorService;
 const ErrorTypes = explorer.components.error.ErrorTypes;
@@ -190,6 +193,13 @@ explorer.components.widget.data_viz.gviz.gvizChart = function(
           let options = angular.copy(scope.widgetConfig.model.chart.options);
 
           let data = scope.widgetConfig.state().datasource.data;
+
+          // Apply styles from the config to the DataTable.
+          if (data) {
+            columnStyleService.applyToDataTable(
+                scope.widgetConfig.model.chart.columns, data);
+          }
+
           chartWrapper.setDataTable(data);
 
           // Force height and width options value with state value
@@ -358,7 +368,10 @@ explorer.components.widget.data_viz.gviz.gvizChart = function(
       let applyDataView = function() {
         let dataViewsJson = dataViewService.create(
             scope.widgetConfig.state().datasource.data,
-            scope.widgetConfig.model.datasource.view);
+            scope.widgetConfig.model.datasource.view,
+            columnStyleService.getEffectiveColumns(
+                scope.widgetConfig.model.chart.columns,
+                scope.widgetConfig.state().datasource.data));
 
         if (dataViewsJson.error) {
           // TODO: Display error in the UI instead of in the console.

--- a/client/components/widget/data_viz/gviz/gviz-directive_test.js
+++ b/client/components/widget/data_viz/gviz/gviz-directive_test.js
@@ -28,7 +28,7 @@ goog.require('p3rf.perfkit.explorer.models.ChartWidgetConfig');
 goog.require('p3rf.perfkit.explorer.models.ResultsDataStatus');
 goog.require('p3rf.perfkit.explorer.models.WidgetType');
 
-fdescribe('gvizDirective', function() {
+describe('gvizDirective', function() {
   var ChartType = p3rf.perfkit.explorer.models.ChartType;
   var directiveElement;
   var ChartWidgetConfig =

--- a/client/components/widget/data_viz/gviz/gviz-directive_test.js
+++ b/client/components/widget/data_viz/gviz/gviz-directive_test.js
@@ -28,7 +28,7 @@ goog.require('p3rf.perfkit.explorer.models.ChartWidgetConfig');
 goog.require('p3rf.perfkit.explorer.models.ResultsDataStatus');
 goog.require('p3rf.perfkit.explorer.models.WidgetType');
 
-describe('gvizDirective', function() {
+fdescribe('gvizDirective', function() {
   var ChartType = p3rf.perfkit.explorer.models.ChartType;
   var directiveElement;
   var ChartWidgetConfig =

--- a/client/mocks/mocks.js
+++ b/client/mocks/mocks.js
@@ -109,6 +109,7 @@ mocks.addMocks = function(appModule) {
                     },
                     chart: {
                       chartType: 'LineChart',
+                      columns: [],
                       options: {
                         title: 'API Response 1',
                         vAxis: {
@@ -140,6 +141,7 @@ mocks.addMocks = function(appModule) {
                     },
                     chart: {
                       chartType: 'LineChart',
+                      columns: [],
                       options: {
                         title: 'API Response 2',
                         vAxis: {
@@ -171,6 +173,7 @@ mocks.addMocks = function(appModule) {
                     },
                     chart: {
                       chartType: 'LineChart',
+                      columns: [],
                       options: {
                         title: 'API Response 3',
                         vAxis: {
@@ -202,6 +205,7 @@ mocks.addMocks = function(appModule) {
                     },
                     chart: {
                       chartType: 'LineChart',
+                      columns: [],
                       options: {
                         title: 'API Response 4',
                         vAxis: {
@@ -247,6 +251,7 @@ mocks.addMocks = function(appModule) {
                     },
                     chart: {
                       chartType: 'Table',
+                      columns: [],
                       options: {
                         title: 'API Response 5',
                         vAxis: {
@@ -278,6 +283,7 @@ mocks.addMocks = function(appModule) {
                     },
                     chart: {
                       chartType: 'Table',
+                      columns: [],
                       options: {
                         title: 'API Response 6',
                         vAxis: {
@@ -315,6 +321,7 @@ mocks.addMocks = function(appModule) {
                     },
                     chart: {
                       chartType: 'LineChart',
+                      columns: [],
                       options: {
                         title: 'API Response 7',
                         vAxis: {

--- a/client/models/chart_widget_model.js
+++ b/client/models/chart_widget_model.js
@@ -34,10 +34,14 @@ goog.require('p3rf.perfkit.explorer.models.WidgetModel');
 goog.require('p3rf.perfkit.explorer.models.WidgetState');
 goog.require('p3rf.perfkit.explorer.models.WidgetType');
 goog.require('p3rf.perfkit.explorer.models.perfkit_simple_builder.QueryConfigModel');
+goog.require('p3rf.perfkit.explorer.components.widget.data_viz.gviz.column_style.ColumnStyleModel');
+
 
 goog.scope(function() {
 const explorer = p3rf.perfkit.explorer;
 const QueryConfigModel = explorer.models.perfkit_simple_builder.QueryConfigModel;
+const ColumnStyleModel = (
+    explorer.components.widget.data_viz.gviz.column_style.ColumnStyleModel);
 const WidgetType = explorer.models.WidgetType;
 
 

--- a/client/models/chart_widget_model.js
+++ b/client/models/chart_widget_model.js
@@ -117,6 +117,12 @@ p3rf.perfkit.explorer.models.ChartModel = function() {
     'chartArea': {},
     'legend': {}
   };
+
+  /**
+   * @type {!Array.<!ColumnStyleModel}
+   * @export
+   */
+  this.columns = [];
 };
 const ChartModel = p3rf.perfkit.explorer.models.ChartModel;
 


### PR DESCRIPTION
* A new Columns tab is now available when a widget is selected.
* Column styles can be added, providing a column id (the field from your SQL query) and an optional title.  Specifying a title will use the provided value in place of the axis/legend/series title in a chart or table.
* Column styles can be reordered.  This will cause the chart/table columns to appear in the same order.
  * note: this has no effect if you're using the view.columns in json, or using the pivot's "sort columns" feature.  UX for both of these will be folded into the Columns sidebar before release.
* If a column is not specified in the styles UX but is present in the dataTable, it will be appended to the end of the table/view.
