### PR TITLE
Move Widget Config tab to the top of widget tabs

### DIFF
--- a/client/components/dashboard/dashboard-service.js
+++ b/client/components/dashboard/dashboard-service.js
@@ -323,6 +323,7 @@ DashboardService.prototype.setDashboard = function(dashboardConfig) {
       for (let widget of container.model.container.children) {
         this.explorerStateService_.widgets.all[widget.model.id] = widget;
         if (widget.model.id === this.explorerStateService_.widgets.selectedId) {
+
           this.selectWidget(
               widget, this.explorerStateService_.containers.selected, true);
         }
@@ -391,12 +392,6 @@ DashboardService.prototype.selectWidget = function(
     this.scrollWidgetIntoView(widget);
   });
 
-  // Select the first widget-based tab, if not already active.
-  if (!this.sidebarTabService_.selectedTab ||
-      !this.sidebarTabService_.selectedTab.requireWidget) {
-    this.sidebarTabService_.selectedTab = this.sidebarTabService_.getFirstTab(true);
-  }
-
   if (!opt_supressStateChange) {
     params = {widget: undefined, container: undefined};
 
@@ -404,6 +399,9 @@ DashboardService.prototype.selectWidget = function(
     if (container) { params.container = container.model.id };
 
     this.$state_.go('explorer-dashboard-edit', params);
+  } else {
+    this.sidebarTabService_.selectTab(
+        this.sidebarTabService_.getFirstWidgetTab());
   }
 };
 

--- a/client/components/dashboard/dashboard-service.js
+++ b/client/components/dashboard/dashboard-service.js
@@ -323,7 +323,6 @@ DashboardService.prototype.setDashboard = function(dashboardConfig) {
       for (let widget of container.model.container.children) {
         this.explorerStateService_.widgets.all[widget.model.id] = widget;
         if (widget.model.id === this.explorerStateService_.widgets.selectedId) {
-
           this.selectWidget(
               widget, this.explorerStateService_.containers.selected, true);
         }
@@ -386,6 +385,12 @@ DashboardService.prototype.selectWidget = function(
 
   if (widget) {
     widget.state().selected = true;
+
+    if (!(this.sidebarTabService_.selectedTab &&
+          this.sidebarTabService_.selectedTab.requireWidget)) {
+      this.sidebarTabService_.selectTab(
+          this.sidebarTabService_.getFirstWidgetTab());
+    }
   }
 
   this.timeout_(() => {
@@ -399,9 +404,6 @@ DashboardService.prototype.selectWidget = function(
     if (container) { params.container = container.model.id };
 
     this.$state_.go('explorer-dashboard-edit', params);
-  } else {
-    this.sidebarTabService_.selectTab(
-        this.sidebarTabService_.getFirstWidgetTab());
   }
 };
 

--- a/client/components/dashboard/dashboard-service_test.js
+++ b/client/components/dashboard/dashboard-service_test.js
@@ -133,13 +133,13 @@ describe('dashboardService', function() {
 
         expect(widget.state().selected).toBeFalsy();
       });
-      
+
       it('should select the first widget tab if no tab is selected',
           function() {
-        expect(sidebarTabService.selectedTab).toBe(null);
+        sidebarTabService.selectedTab = null;
 
         svc.selectWidget(widget, container);
-        $rootScope.$apply();
+        $rootScope.$digest();
 
         expect(sidebarTabService.selectedTab).toBe(sidebarTabService.tabs[2]);
         expect(sidebarTabService.selectedTab.requireWidget).toBeTrue();

--- a/client/components/explorer/explorer-service.js
+++ b/client/components/explorer/explorer-service.js
@@ -56,8 +56,8 @@ const ExplorerModel = explorer.components.explorer.ExplorerModel;
 explorer.components.explorer.ExplorerService = function(
     arrayUtilService, containerService, dashboardDataService,
     dashboardService, dashboardVersionService, errorService,
-    explorerStateService, $location, $state, $stateParams,
-    $rootScope, $timeout) {
+    explorerStateService, sidebarTabService, $location, $state,
+    $stateParams, $rootScope, $timeout) {
   /**
    * @type {!ArrayUtilService}
    * @private
@@ -78,6 +78,9 @@ explorer.components.explorer.ExplorerService = function(
 
   /** @private {!ExplorerStateService} */
   this.explorerStateService_ = explorerStateService;
+
+  /** @private {!SidebarTabService} */
+  this.sidebarTabService_ = sidebarTabService;
 
   /** @private */
   this.location_ = $location;
@@ -189,6 +192,15 @@ explorer.components.explorer.ExplorerService = function(
             }
           });
 
+          // If a widget is selected, make sure a widget tab is selected.
+          if ($stateParams.widget) {
+            if (!this.sidebarTabService_.selectedTab ||
+                !this.sidebarTabService_.selectedTab.requireWidget) {
+              this.sidebarTabService_.selectTab(
+                  this.sidebarTabService_.getFirstWidgetTab());     
+            }
+          }
+          
           // If any dashboard parameters changed, refresh the dashboard.
           angular.forEach(this.dashboard.params, param => {
             if ($location.search()[param.name] !==

--- a/client/components/explorer/sidebar/sidebar-tab-service.js
+++ b/client/components/explorer/sidebar/sidebar-tab-service.js
@@ -36,6 +36,10 @@ explorer.components.explorer.sidebar.SIDEBAR_TABS = [
     hint: 'Container properties and text',
     tabClass: 'dashboard-tab', panelTitleClass: 'dashboard-panel-title',
     panelClass: 'dashboard-panel', toolbarClass: 'dashboard-toolbar'},
+  {id: 'widget.config', title: 'Widget', iconClass: 'fa fa-cube',
+    hint: 'Widget title and appearance', requireWidget: true,
+    tabClass: 'widget-tab', panelTitleClass: 'widget-panel-title',
+    panelClass: 'widget-panel', toolbarClass: 'widget-toolbar'},
   {id: 'widget.data.filter', title: 'Data Filters', iconClass: 'fa fa-filter',
     hint: 'Query filters and constraints', requireWidget: true,
     tabClass: 'bqgviz-tab', panelTitleClass: 'bqgviz-panel-title',
@@ -48,10 +52,6 @@ explorer.components.explorer.sidebar.SIDEBAR_TABS = [
     hint: 'Chart type and settings', requireWidget: true,
     tabClass: 'bqgviz-tab', panelTitleClass: 'bqgviz-panel-title',
     panelClass: 'bqgviz-panel', toolbarClass: 'bqgviz-toolbar'},
-  {id: 'widget.config', title: 'Widget', iconClass: 'fa fa-font',
-    hint: 'Widget title and appearance', requireWidget: true,
-    tabClass: 'widget-tab', panelTitleClass: 'widget-panel-title',
-    panelClass: 'widget-panel', toolbarClass: 'widget-toolbar'},
   {id: 'widget.columns', title: 'Columns', iconClass: 'fa fa-columns',
     hint: 'Column styling and order', requireWidget: true,
     tabClass: 'widget-tab', panelTitleClass: 'widget-panel-title',
@@ -100,37 +100,32 @@ SidebarTabService.prototype.toggleTab = function(tab) {
   }
 };
 
+
 /**
- * Selects the first available tab.
- * @param {?boolean=} opt_requireWidget If true, returns the first tab
- *     where requireWidget is true.  Otherwise, returns the first tab.
+ * Selects the first available widget-related tab.
  * @return {?ExplorerTabModel}
  */
-SidebarTabService.prototype.getFirstTab = function(opt_requireWidget = false) {
-  if (this.explorerStateSvc_.widgets.selectedId) {
-    if (opt_requireWidget) {
-      for (let i=0, len=this.tabs.length; i < len; ++i) {
-        let currentTab = this.tabs[i];
-  
-        if (currentTab.requireWidget) {
-          return currentTab;
-        }
-      }
-    } else {
-      return this.tabs[0];
-    }
-  } else {
-    for (let i=0, len=this.tabs.length; i < len; ++i) {
-      let currentTab = this.tabs[i];
+SidebarTabService.prototype.getFirstWidgetTab = function() {
+  for (let i=0, len=this.tabs.length; i < len; ++i) {
+    let currentTab = this.tabs[i];
 
-      if (!currentTab.requireWidget) {
-        return currentTab;
-      }
+    if (currentTab.requireWidget) {
+      return currentTab;
     }
   }
 
-  console.log('getFirstTab failed: No non-widget tabs available.');
+  console.log('getFirstWidgetTab failed: No widget tabs available.');
 };
+
+
+/**
+ * Selects the first available tab.
+ * @return {?ExplorerTabModel}
+ */
+SidebarTabService.prototype.getFirstTab = function() {
+  return this.tabs[0];
+};
+
 
 SidebarTabService.prototype.getLastTab = function() {
   if (this.explorerStateSvc_.widgets.selectedId) {

--- a/client/components/explorer/sidebar/sidebar-tab-service_test.js
+++ b/client/components/explorer/sidebar/sidebar-tab-service_test.js
@@ -59,7 +59,7 @@ describe('SidebarTabService', function() {
     explorerSvc = explorerService;
     $rootScope = _$rootScope_;
 
-    explorerSvc.newDashboard();
+    explorerSvc.newDashboard(true, false);
     $rootScope.$digest();
   }));
 
@@ -110,10 +110,12 @@ describe('SidebarTabService', function() {
   });
 
   describe('should support functions for getting the', function() {
-    var dashboardSvc;
+    var dashboardSvc, container, widget;
 
     beforeEach(inject(function(_dashboardService_) {
       dashboardSvc = _dashboardService_;
+      container = dashboardSvc.newContainer(false);
+      widget = dashboardSvc.addWidget(container, false);
 
       sidebarTabSvc.tabs = mockTabs;
     }));
@@ -131,35 +133,36 @@ describe('SidebarTabService', function() {
     });
 
     it('last tab when a widget is selected', function() {
-      dashboardSvc.selectedWidget = {'type': 'Mock Widget'};
+      dashboardSvc.selectWidget(widget, container);
+      $rootScope.$apply();
 
       expect(sidebarTabSvc.getLastTab()).toEqual(mockTabs[3]);
     });
 
     it('last tab when moving previous from the first tab', function() {
-      dashboardSvc.selectedWidget = {'type': 'Mock Widget'};
+      dashboardSvc.selectWidget(widget, container);
+      $rootScope.$apply();
 
       sidebarTabSvc.selectTab(mockTabs[0]);
       expect(sidebarTabSvc.getPreviousTab()).toEqual(mockTabs[3]);
     });
 
     it('next global tab when no widget is selected', function() {
-      dashboardSvc.unselectWidget();
-      $rootScope.$digest();
-
       sidebarTabSvc.selectTab(mockTabs[0]);
       expect(sidebarTabSvc.getNextTab()).toEqual(mockTabs[2]);
     });
 
     it('next available tab when a widget is selected', function() {
-      dashboardSvc.selectedWidget = {'type': 'Mock Widget'};
+      dashboardSvc.selectWidget(widget, container);
+      $rootScope.$apply();
 
       sidebarTabSvc.selectTab(mockTabs[0]);
       expect(sidebarTabSvc.getNextTab()).toEqual(mockTabs[1]);
     });
 
     it('first available tab when next exceeds the end of the list', function() {
-      dashboardSvc.selectedWidget = {'type': 'Mock Widget'};
+      dashboardSvc.selectWidget(widget, container);
+      $rootScope.$apply();
 
       sidebarTabSvc.selectTab(mockTabs[3]);
       expect(sidebarTabSvc.getNextTab()).toEqual(mockTabs[0]);
@@ -174,14 +177,16 @@ describe('SidebarTabService', function() {
     });
 
     it('previous available tab when a widget is selected', function() {
-      dashboardSvc.selectedWidget = {'type': 'Mock Widget'};
+      dashboardSvc.selectWidget(widget, container);
+      $rootScope.$apply();
 
       sidebarTabSvc.selectTab(mockTabs[2]);
       expect(sidebarTabSvc.getPreviousTab()).toEqual(mockTabs[1]);
     });
 
     it('last available tab when previous precedes the start of the list', function() {
-      dashboardSvc.selectedWidget = {'type': 'Mock Widget'};
+      dashboardSvc.selectWidget(widget, container);
+      $rootScope.$apply();
 
       sidebarTabSvc.selectTab(mockTabs[0]);
       expect(sidebarTabSvc.getPreviousTab()).toEqual(mockTabs[3]);


### PR DESCRIPTION
Also changes the icon to a box, and fixes an issue with selecting the top widget when initially loading the dashboard or selecting a widget.