### PR TITLE
Improve Container Selection

### DIFF
--- a/client/components/dashboard/dashboard-directive.html
+++ b/client/components/dashboard/dashboard-directive.html
@@ -22,9 +22,10 @@
                   ng-hide="explorerSvc.model.readOnly"
                   ng-click="dashboardSvc.removeWidget(widget, container)"></span>
             <span class="glyphicon glyphicon-refresh pk-widget-button"
-                  ng-click="clickRefreshWidget(widget)"></span>
+                  ng-click="clickRefreshWidget($event, widget)"></span>
             <a class="pk-widget-button"
                ng-show="widget.model.url"
+               ng-click="$event.stopPropagation()"
                ng-href="{{ dashboardSvc.replaceTokens(widget.model.url) }}">
               <span class="glyphicon glyphicon-link"></span>
             </a>

--- a/client/components/dashboard/dashboard-directive.html
+++ b/client/components/dashboard/dashboard-directive.html
@@ -3,7 +3,7 @@
   <div class="spinner" ng-show="explorerSvc.model.dashboardIsLoading"></div>
 
   <div ng-repeat="container in dashboardSvc.containers"
-       class="pk-container pk-background"
+       class="pk-container pk-container-{{ container.model.id }} pk-background"
        ng-class="{'pk-container-selected': container.state().selected}">
 
     <container class="pk-container-content" layout="column"

--- a/client/components/dashboard/dashboard-directive.html
+++ b/client/components/dashboard/dashboard-directive.html
@@ -7,7 +7,8 @@
        ng-class="{'pk-container-selected': container.state().selected}">
 
     <container class="pk-container-content" layout="column"
-               ng-model="container.model">
+               ng-model="container.model"
+               ng-click="clickContainer($event, container)">
       <div ng-show="container.model.container.header_text"
            class="pk-container-header">
         {{ container.model.container.header_text }}
@@ -21,19 +22,19 @@
                   ng-hide="explorerSvc.model.readOnly"
                   ng-click="dashboardSvc.removeWidget(widget, container)"></span>
             <span class="glyphicon glyphicon-refresh pk-widget-button"
-                  ng-click="dashboardSvc.refreshWidget(widget)"></span>
+                  ng-click="clickRefreshWidget(widget)"></span>
             <a class="pk-widget-button"
                ng-show="widget.model.url"
                ng-href="{{ dashboardSvc.replaceTokens(widget.model.url) }}">
               <span class="glyphicon glyphicon-link"></span>
             </a>
             <div class="pk-widget-title"
-                 ng-click="dashboardSvc.selectWidget(widget, container)"
+                 ng-click="clickWidget($event, widget, container)"
                  ng-bind="dashboardSvc.replaceTokens(widget.model.title)"></div>
           </div>
           <div class="pk-widget-content"
                style="min-height: {{ container.model.container.height }}px"
-               ng-click="dashboardSvc.selectWidget(widget, container)">
+               ng-click="clickWidget($event, widget, container)">
             <gviz-chart-widget widget-config="widget"/>
           </div>
           <div class="pk-widget-footer" ng-show="widget.model.show_statistics">

--- a/client/components/dashboard/dashboard-directive.js
+++ b/client/components/dashboard/dashboard-directive.js
@@ -55,9 +55,23 @@ explorer.components.dashboard.DashboardDirective = function() {
       /** @export */
       $scope.explorerSvc = explorerService;
 
-      $scope.logError = function(msg) {
-        console.log(msg);
-      };
+      /** @export */
+      $scope.clickRefreshWidget = function(event, widget) {
+        dashboardService.refreshWidget(widget);
+        event.stopPropagation();
+      }
+
+      /** @export */
+      $scope.clickContainer = function(event, container) {
+        dashboardService.selectWidget(null, container);
+        event.stopPropagation();
+      }
+
+      /** @export */
+      $scope.clickWidget = function(event, widget, container) {
+        dashboardService.selectWidget(widget, container);
+        event.stopPropagation();
+      }
     }]
   };
 };

--- a/client/components/dashboard/dashboard-service.js
+++ b/client/components/dashboard/dashboard-service.js
@@ -409,6 +409,12 @@ DashboardService.prototype.selectWidget = function(
     this.timeout_(() => {
       this.scrollContainerIntoView(container);
     });
+  } else {
+    if (this.sidebarTabService_.selectedTab &&
+        !this.sidebarTabService_.isTabVisible(this.sidebarTabService_.selectedTab)) {
+      this.sidebarTabService_.selectTab(
+          this.sidebarTabService_.getFirstTab());
+    }
   }
 
   if (!opt_supressStateChange) {
@@ -849,13 +855,7 @@ DashboardService.prototype.onDashboardClick = function(event) {
  * Unselect the currently selected widget and container, if any.
  */
 DashboardService.prototype.unselectWidget = function() {
-  let currentSelection = this.explorerStateService_.widgets.selected;
-
-  if (currentSelection) {
-    currentSelection.state().selected = false;
-  }
-
-  this.explorerStateService_.selectWidget(null, null);
+  this.selectWidget(null, null);
 };
 
 

--- a/client/components/dashboard/dashboard-service.js
+++ b/client/components/dashboard/dashboard-service.js
@@ -319,6 +319,10 @@ DashboardService.prototype.setDashboard = function(dashboardConfig) {
       if (container.model.id ===
           this.explorerStateService_.containers.selectedId) {
         container.state().selected = true;
+
+        if (!this.explorerStateService_.widgets.selectedId) {
+          this.selectWidget(null, container, true);
+        }
       }
       for (let widget of container.model.container.children) {
         this.explorerStateService_.widgets.all[widget.model.id] = widget;
@@ -395,6 +399,10 @@ DashboardService.prototype.selectWidget = function(
     this.timeout_(() => {
       this.scrollWidgetIntoView(widget);
     });
+  } else if (container) {
+    this.timeout_(() => {
+      this.scrollContainerIntoView(container);
+    });
   }
 
   if (!opt_supressStateChange) {
@@ -408,15 +416,41 @@ DashboardService.prototype.selectWidget = function(
 };
 
 
-DashboardService.prototype.scrollWidgetIntoView = function(widget) {
-  let widgetElement = angular.element(
-      document.getElementsByClassName('pk-widget-' + widget.model.id));
-  let contentElement = angular.element(
-      document.getElementsByClassName('pk-page-content'));
 
-  if ((widgetElement.length === 1) && (contentElement.length === 1)) {
-    goog.style.scrollIntoContainerView(widgetElement[0], contentElement[0]);
+/**
+ * Scrolls the specified content element (typically a widget or container) into view.
+ * @param {!angular.Element} targetElement The element to scroll into view.
+ */
+DashboardService.prototype.scrollPageElementIntoView = function(targetElement) {
+  let contentElement = angular.element(document.getElementsByClassName('pk-page-content'));
+
+  if ((targetElement.length === 1) && (contentElement.length === 1)) {
+    goog.style.scrollIntoContainerView(targetElement[0], contentElement[0]);
   }
+};
+
+
+/**
+ * Scrolls the specified container into view.
+ * @param {!ContainerConfig} container
+ */
+DashboardService.prototype.scrollContainerIntoView = function(container) {
+  let targetElement = angular.element(
+      document.getElementsByClassName('pk-container-' + container.model.id));
+
+  this.scrollPageElementIntoView(targetElement);
+};
+
+
+/**
+ * Scrolls the specified widget into view.
+ * @param {!WidgetConfig} widget
+ */
+DashboardService.prototype.scrollWidgetIntoView = function(widget) {
+  let targetElement = angular.element(
+      document.getElementsByClassName('pk-widget-' + widget.model.id));
+
+  this.scrollPageElementIntoView(targetElement);
 };
 
 

--- a/client/components/dashboard/dashboard-service.js
+++ b/client/components/dashboard/dashboard-service.js
@@ -391,11 +391,11 @@ DashboardService.prototype.selectWidget = function(
       this.sidebarTabService_.selectTab(
           this.sidebarTabService_.getFirstWidgetTab());
     }
-  }
 
-  this.timeout_(() => {
-    this.scrollWidgetIntoView(widget);
-  });
+    this.timeout_(() => {
+      this.scrollWidgetIntoView(widget);
+    });
+  }
 
   if (!opt_supressStateChange) {
     params = {widget: undefined, container: undefined};

--- a/client/components/dashboard/dashboard-service.js
+++ b/client/components/dashboard/dashboard-service.js
@@ -371,25 +371,29 @@ DashboardService.prototype.initializeParams_ = function() {
  */
 DashboardService.prototype.selectWidget = function(
     widget, container, opt_supressStateChange) {
+  let currentContainer = this.explorerStateService_.containers.selected;
   let currentWidget = this.explorerStateService_.widgets.selected;
 
-  if (currentWidget) {
-    currentWidget.state().selected = false;
+  if (currentWidget !== widget) {
+    currentWidget && (currentWidget.state().selected = false);
+    widget && (widget.state().selected = true);
   }
 
-  let currentContainer = this.explorerStateService_.containers.selected;
-
-  if (currentContainer && currentContainer !== container) {
-    currentContainer.state().selected = false;
+  if (currentContainer !== container) {
+    currentContainer && (currentContainer.state().selected = false);
+    container && (container.state().selected = true);
   }
 
-  if (container && currentContainer !== container) {
-    container.state().selected = true;
+  if (!opt_supressStateChange) {
+    params = {widget: undefined, container: undefined};
+
+    if (widget) { params.widget = widget.model.id; }
+    if (container) { params.container = container.model.id };
+
+    this.$state_.go('explorer-dashboard-edit', params);
   }
 
   if (widget) {
-    widget.state().selected = true;
-
     if (this.sidebarTabService_.selectedTab &&
         !this.sidebarTabService_.selectedTab.requireWidget) {
       this.sidebarTabService_.selectTab(
@@ -410,20 +414,13 @@ DashboardService.prototype.selectWidget = function(
       this.scrollContainerIntoView(container);
     });
   } else {
-    if (this.sidebarTabService_.selectedTab &&
-        !this.sidebarTabService_.isTabVisible(this.sidebarTabService_.selectedTab)) {
-      this.sidebarTabService_.selectTab(
-          this.sidebarTabService_.getFirstTab());
-    }
-  }
-
-  if (!opt_supressStateChange) {
-    params = {widget: undefined, container: undefined};
-
-    if (widget) { params.widget = widget.model.id; }
-    if (container) { params.container = container.model.id };
-
-    this.$state_.go('explorer-dashboard-edit', params);
+    this.timeout_(() => {      
+      if (this.sidebarTabService_.selectedTab &&
+          !this.sidebarTabService_.isTabVisible(this.sidebarTabService_.selectedTab)) {
+        this.sidebarTabService_.selectTab(
+            this.sidebarTabService_.getFirstTab());
+      }
+    });
   }
 };
 

--- a/client/components/explorer/explorer-service.js
+++ b/client/components/explorer/explorer-service.js
@@ -199,6 +199,20 @@ explorer.components.explorer.ExplorerService = function(
               this.sidebarTabService_.selectTab(
                   this.sidebarTabService_.getFirstWidgetTab());
             }
+          } else if ($stateParams.container) {
+            // Otherwise, if a container is selected, make sure a container tab is selected.
+            if (!(this.sidebarTabService_.selectedTab &&
+                 this.sidebarTabService_.selectedTab.requireContainer)) {
+              this.sidebarTabService_.selectTab(
+                  this.sidebarTabService_.getFirstContainerTab());
+            }
+          } else {
+            // Otherwise, select the first global tab if another tab is selected.
+            if (this.sidebarTabService_.selectedTab &&
+                 !this.sidebarTabService_.isTabVisible(this.sidebarTabService_.selectedTab)) {
+              this.sidebarTabService_.selectTab(
+                  this.sidebarTabService_.getFirstTab());
+            }
           }
 
           // If any dashboard parameters changed, refresh the dashboard.

--- a/client/components/explorer/explorer-state-service.js
+++ b/client/components/explorer/explorer-state-service.js
@@ -108,10 +108,17 @@ ExplorerStateService.prototype.selectWidget = function(
     containerId, widgetId) {
   let params = {};
   let valid = true;
+  let targetContainer, targetWidget = null;
+
+  if (this.containers.selected) {
+    this.containers.selected.state().selected = false;
+  }
 
   if (containerId) {
-    if (goog.isDefAndNotNull(this.containers.all[containerId])) {
+    targetContainer = this.containers.all[containerId];
+    if (goog.isDefAndNotNull(targetContainer)) {
       params['container'] = containerId;
+      targetContainer.state().selected = true;
     } else {
       this.errorSvc_.addError(ErrorTypes.DANGER,
         'Selection failed: container id ' + containerId + ' does not exist.');
@@ -121,16 +128,23 @@ ExplorerStateService.prototype.selectWidget = function(
     params['container'] = null;
   }
 
+  if (this.widgets.selected) {
+    this.widgets.selected.state().selected = false;
+  }
+
   if (widgetId) {
-    if (goog.isDefAndNotNull(this.widgets.all[widgetId])) {
+    targetWidget = this.widgets.all[widgetId];
+
+    if (goog.isDefAndNotNull(targetWidget)) {
       params['widget'] = widgetId;
+      targetWidget.state().selected = true;
     } else {
       this.errorSvc_.addError(ErrorTypes.DANGER,
         'Selection failed: widget id ' + widgetId + ' does not exist.');
       valid = false;
     }
   } else {
-    params['widget'] = null;    
+    params['widget'] = null;
   }
 
   if (valid) {

--- a/client/components/explorer/explorer-state-service_test.js
+++ b/client/components/explorer/explorer-state-service_test.js
@@ -21,23 +21,31 @@
 
 goog.require('p3rf.perfkit.explorer.components.explorer.ExplorerStateService');
 goog.require('p3rf.perfkit.explorer.components.explorer.ExplorerStateModel');
+goog.require('p3rf.perfkit.explorer.components.container.ContainerWidgetConfig');
+goog.require('p3rf.perfkit.explorer.models.WidgetConfig');
 
 
 describe('ExplorerStateService', function() {
   var svc, $rootScope, $state;
-  var errorSvc;
+  var errorSvc, explorerSvc, containerService;
 
   const explorer = p3rf.perfkit.explorer;
   const ExplorerStateModel = explorer.components.explorer.ExplorerStateModel;
+  const ContainerWidgetConfig = explorer.components.container.ContainerWidgetConfig;
+  const WidgetConfig = explorer.models.WidgetConfig;
 
   beforeEach(module('explorer'));
 
   beforeEach(inject(function(
-      _$rootScope_, _$state_, explorerStateService, errorService) {
+      _$rootScope_, _$state_, explorerStateService, errorService, explorerService, containerService) {
     $rootScope = _$rootScope_;
     $state = _$state_;
     svc = explorerStateService;
     errorSvc = errorService;
+    containerSvc = containerService;
+    explorerSvc = explorerService;
+
+    explorerSvc.newDashboard(false);
   }));
 
   describe('should correctly initialize', function() {
@@ -56,32 +64,38 @@ describe('ExplorerStateService', function() {
     var widget1, widget2, container1, container2;
 
     beforeEach(inject(function() {
-      widget1 = {model: {id: 'w1', title: 'widget 1'}};
-      widget2 = {model: {id: 'w2', title: 'widget 2'}};
-      container1 = {model: {id: 'c1', title: 'container 1'}};
-      container2 = {model: {id: 'c2', title: 'container 2'}};
+      container1 = containerSvc.insert(true, false);
+      container2 = containerSvc.insert(true, false);
 
-      svc.widgets.add(widget1);
-      svc.widgets.add(widget2);
-      svc.containers.add(container1);
-      svc.containers.add(container2);
+      widget1 = container1.model.container.children[0];
+      widget2 = container2.model.container.children[0];
     }));
 
     describe('selectWidget', function() {
       it('should select items by id', function() {
+        expect(svc.containers.selected).toBeNull();
+        expect(svc.widgets.selected).toBeNull();
+
         svc.selectWidget(container2.model.id, widget2.model.id);
         $rootScope.$apply();
 
         expect(svc.containers.selected).toEqual(container2);
+        expect(container2.state().selected).toBeTrue();
         expect(svc.widgets.selected).toEqual(widget2);
+        expect(widget2.state().selected).toBeTrue();
       });
 
       it('should unselect items when NULL is passed', function() {
+        svc.selectWidget(container1.model.id, widget1.model.id);
+        $rootScope.$apply();
+
         svc.selectWidget(null, null);
         $rootScope.$apply();
 
         expect(svc.containers.selected).toBeNull();
+        expect(container2.state().selected).toBeFalse();
         expect(svc.widgets.selected).toBeNull();
+        expect(container2.state().selected).toBeFalse();
       });
 
       describe('should write to the log when providing an invalid',

--- a/client/components/explorer/sidebar/sidebar-directive.html
+++ b/client/components/explorer/sidebar/sidebar-directive.html
@@ -2,7 +2,7 @@
   ng-show="tabSvc.selectedTab">
 
   <div class="pk-sidebar-panel-header
-              {{ tabSvc.selectedTab.panelTitleClass}}">
+              {{ tabSvc.selectedTab.panelTitleClass }}">
     <div style="float: right">
       <md-button ng-click="tabSvc.toggleTab(tabSvc.selectedTab)"
           aria-label="close panel">
@@ -15,6 +15,8 @@
 
   <div class="pk-sidebar-panel-content
               {{ tabSvc.selectedTab.panelClass }}" flex>
+
+    <!-- TODO(joemu): Replace this switch with a data-driven approach. -->
     <div ng-switch="tabSvc.selectedTab.id">
 
       <div ng-switch-when="dashboard">

--- a/client/components/explorer/sidebar/sidebar-tab-model.js
+++ b/client/components/explorer/sidebar/sidebar-tab-model.js
@@ -57,7 +57,7 @@ explorer.components.explorer.sidebar.SidebarTabModel = class {
      * PerfKit Explorer currently supports icons from the following sources:
      *   Font Awesome: https://fortawesome.github.io/Font-Awesome/icons/
      *   Bootstrap: http://getbootstrap.com/components/#glyphicons
-     *     an implementation of Glyphicons: http://glyphicons.com/
+     *     (an implementation of Glyphicons: http://glyphicons.com/)
      * @export {string}
      */
     this.iconClass = '';

--- a/client/components/explorer/sidebar/sidebar-tab-model.js
+++ b/client/components/explorer/sidebar/sidebar-tab-model.js
@@ -1,0 +1,95 @@
+/**
+ * @copyright Copyright 2015 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @fileoverview columnStyleService is a model encapsulating the properties
+ * of a column style.  In practice, it is contained in a heterogenous array.
+ * @author joemu@google.com (Joe Allan Muharsky)
+ */
+
+goog.provide('p3rf.perfkit.explorer.components.explorer.sidebar.SidebarTabModel');
+
+
+goog.scope(function() {
+const explorer = p3rf.perfkit.explorer;
+
+
+/**
+ * See module docstring for more information about purpose and usage.
+ *
+ * @export
+ */
+explorer.components.explorer.sidebar.SidebarTabModel = class {
+  constructor() {
+    /**
+     * A string that uniquely represents the tab in the sidebar.
+     * @export {string}
+     */
+    this.id = '';
+
+    /**
+     * A string used as the label and heading for the tab.
+     * @export {string}
+     */
+    this.title = '';
+
+    /**
+     * A string that is used for the tab's tooltip.
+     * @export {string}
+     */
+    this.hint = '';
+
+    /**
+     * The CSS class name used for the icon representation of the tab.
+     * See sidebar-tabs-directive.html for details on iconClass application.
+     *
+     * PerfKit Explorer currently supports icons from the following sources:
+     *   Font Awesome: https://fortawesome.github.io/Font-Awesome/icons/
+     *   Bootstrap: http://getbootstrap.com/components/#glyphicons
+     *     an implementation of Glyphicons: http://glyphicons.com/
+     * @export {string}
+     */
+    this.iconClass = '';
+
+    /**
+     * The CSS class name used for the tab.
+     * See sidebar-tabs-directive.html for details on tabClass application.
+     * @export {string}
+     */
+    this.tabClass = '';
+
+    /**
+     * The CSS class name used for the tab's content.
+     * See sidebar-directive.html for details on panelClass application.
+     * @export {string}
+     */
+    this.panelClass = '';
+
+    /**
+     * The CSS class name used for the title of tab's content.
+     * See sidebar-directive.html for details on panelTitleClass application.
+     * @export {string}
+     */
+    this.panelTitleClass = '';
+
+    /**
+     * The CSS class name used for the tab's toolbar.
+     * See explorer-toolbar-directive.html for details on toolbarClass application.
+     * @export {string}
+     */
+    this.toolbarClass = '';
+  }
+}
+
+});  // goog.scope

--- a/client/components/explorer/sidebar/sidebar-tab-service_test.js
+++ b/client/components/explorer/sidebar/sidebar-tab-service_test.js
@@ -34,7 +34,11 @@ describe('SidebarTabService', function() {
 
   var mockTabs = [
     {id: 'global-a', title: 'Global Tab 1', iconClass: 'global-a-icon',
-     hint: 'Tip for Global Tab 1', requireWidget: false,
+     hint: 'Tip for Global Tab 1',
+     tabClass: 'global-a-tab', panelTitleClass: 'global-a-panel-title',
+     panelClass: 'global-a-panel'},
+    {id: 'container-a', title: 'Container Tab 1', iconClass: 'cont-a-icon',
+     hint: 'Tip for Container Tab 1', requireContainer: true,
      tabClass: 'global-a-tab', panelTitleClass: 'global-a-panel-title',
      panelClass: 'global-a-panel'},
     {id: 'widget-b', title: 'Widget Tab 2', iconClass: 'widget-b-icon',
@@ -120,6 +124,44 @@ describe('SidebarTabService', function() {
       sidebarTabSvc.tabs = mockTabs;
     }));
 
+    describe('tab visibility', function() {
+      it('that return true for global tabs', function() {
+        var actual = sidebarTabSvc.isTabVisible(mockTabs[0]);
+
+        expect(actual).toBeTrue();
+      });
+
+      it('that return false for container tabs when no container is selected', function() {
+        var actual = sidebarTabSvc.isTabVisible(mockTabs[1]);
+
+        expect(actual).toBeFalse();
+      });
+
+      it('that return true for container tabs when a container is selected', function() {
+        dashboardSvc.selectWidget(null, container);
+        $rootScope.$apply();
+
+        var actual = sidebarTabSvc.isTabVisible(mockTabs[1]);
+
+        expect(actual).toBeTrue();
+      });
+
+      it('that return false for widget tabs when no widget is selected', function() {
+        var actual = sidebarTabSvc.isTabVisible(mockTabs[2]);
+
+        expect(actual).toBeFalse();
+      });
+
+      it('that return true for widget tabs when a widget is selected', function() {
+        dashboardSvc.selectWidget(widget, container);
+        $rootScope.$apply();
+
+        var actual = sidebarTabSvc.isTabVisible(mockTabs[2]);
+
+        expect(actual).toBeTrue();
+      });
+    });
+
     it('first available tab', function() {
       expect(sidebarTabSvc.getFirstTab()).toEqual(mockTabs[0]);
     });
@@ -129,14 +171,14 @@ describe('SidebarTabService', function() {
       $rootScope.$digest();
 
       expect(dashboardSvc.selectedWidget).toBeNull();
-      expect(sidebarTabSvc.getLastTab()).toEqual(mockTabs[2]);
+      expect(sidebarTabSvc.getLastTab()).toEqual(mockTabs[3]);
     });
 
     it('last tab when a widget is selected', function() {
       dashboardSvc.selectWidget(widget, container);
       $rootScope.$apply();
 
-      expect(sidebarTabSvc.getLastTab()).toEqual(mockTabs[3]);
+      expect(sidebarTabSvc.getLastTab()).toEqual(mockTabs[4]);
     });
 
     it('last tab when moving previous from the first tab', function() {
@@ -144,27 +186,41 @@ describe('SidebarTabService', function() {
       $rootScope.$apply();
 
       sidebarTabSvc.selectTab(mockTabs[0]);
-      expect(sidebarTabSvc.getPreviousTab()).toEqual(mockTabs[3]);
+      expect(sidebarTabSvc.getPreviousTab()).toEqual(mockTabs[4]);
     });
 
     it('next global tab when no widget is selected', function() {
       sidebarTabSvc.selectTab(mockTabs[0]);
-      expect(sidebarTabSvc.getNextTab()).toEqual(mockTabs[2]);
+      expect(sidebarTabSvc.getNextTab()).toEqual(mockTabs[3]);
     });
 
-    it('next available tab when a widget is selected', function() {
-      dashboardSvc.selectWidget(widget, container);
+    it('next available tab when a container is selected', function() {
+      dashboardSvc.selectWidget(null, container);
       $rootScope.$apply();
 
       sidebarTabSvc.selectTab(mockTabs[0]);
       expect(sidebarTabSvc.getNextTab()).toEqual(mockTabs[1]);
     });
 
+    it('first container tab', function() {
+      dashboardSvc.selectWidget(widget, container);
+      $rootScope.$apply();
+
+      expect(sidebarTabSvc.getFirstContainerTab()).toEqual(mockTabs[1]);
+    });
+
+    it('first widget tab', function() {
+      dashboardSvc.selectWidget(widget, container);
+      $rootScope.$apply();
+
+      expect(sidebarTabSvc.getFirstWidgetTab()).toEqual(mockTabs[2]);
+    });
+
     it('first available tab when next exceeds the end of the list', function() {
       dashboardSvc.selectWidget(widget, container);
       $rootScope.$apply();
 
-      sidebarTabSvc.selectTab(mockTabs[3]);
+      sidebarTabSvc.selectTab(mockTabs[4]);
       expect(sidebarTabSvc.getNextTab()).toEqual(mockTabs[0]);
     });
 
@@ -189,7 +245,7 @@ describe('SidebarTabService', function() {
       $rootScope.$apply();
 
       sidebarTabSvc.selectTab(mockTabs[0]);
-      expect(sidebarTabSvc.getPreviousTab()).toEqual(mockTabs[3]);
+      expect(sidebarTabSvc.getPreviousTab()).toEqual(mockTabs[4]);
     });
   });
 });

--- a/client/components/explorer/sidebar/sidebar-tabs-directive.html
+++ b/client/components/explorer/sidebar/sidebar-tabs-directive.html
@@ -3,7 +3,7 @@
       class="pk-sidebar-tab {{ tab.tabClass }}"
       ng-repeat="tab in ctrl.tabSvc.tabs"
       ng-click="ctrl.tabClicked(tab)"
-      ng-hide="tab.requireWidget && !ctrl.dashboardSvc.selectedWidget"
+      ng-show="ctrl.tabSvc.isTabVisible(tab)"
       ng-class="{'pk-sidebar-tab-selected': ctrl.tabSvc.selectedTab == tab}"
       ng-attr-selected="ctrl.tabSvc.selectedTab == tab">
     <md-tooltip

--- a/client/components/explorer/sidebar/sidebar-tabs-directive.js
+++ b/client/components/explorer/sidebar/sidebar-tabs-directive.js
@@ -53,22 +53,6 @@ explorer.components.explorer.sidebar.SidebarTabsDirective = function() {
         this.tabSvc.toggleTab(tab);
         tab.tooltipVisible = false;
       };
-
-      // When selected widget changes to null, and the selected tab's
-      // requireWidget property is true, select the next visible (non-widget)
-      // tab.
-      $scope.$watch(
-          angular.bind(this, function() {
-            return this.dashboardSvc.selectedWidget; }),
-          angular.bind(this, function(newValue, oldValue) {
-            if (newValue !== oldValue) {
-              if (!newValue && this.tabSvc.selectedTab &&
-                  this.tabSvc.selectedTab.requireWidget) {
-                this.tabSvc.selectedTab = this.tabSvc.getNextTab(
-                    this.tabSvc.selectedTab);
-              }
-            }
-          }));
     }],
     controllerAs: 'ctrl'
   };


### PR DESCRIPTION
* Containers can now be selected by clicking on them
* The Container tab will only show when a container is selected (this implicitly includes widget selection)
* The Sidebar will no longer open when the page loads to a container/widget
* If a Container is selected (but no widget), it will be scrolled into view