### PR TITLE
Fix malformed binding for container moves.

### DIFF
--- a/client/components/container/container-service.js
+++ b/client/components/container/container-service.js
@@ -74,7 +74,8 @@ explorer.components.container.ContainerService = class {
    */
   moveFirst(opt_container) {
     this.move_(
-        angular.bind(arrayUtilSvc, arrayUtilSvc.moveFirst), opt_container);
+        angular.bind(this.arrayUtilSvc, this.arrayUtilSvc.moveFirst),
+        opt_container);
   };
 
   /**
@@ -86,7 +87,8 @@ explorer.components.container.ContainerService = class {
    */
   movePrevious(opt_container) {
     this.move_(
-        angular.bind(arrayUtilSvc, arrayUtilSvc.movePrevious), opt_container);
+        angular.bind(this.arrayUtilSvc, this.arrayUtilSvc.movePrevious),
+        opt_container);
   };
 
   /**
@@ -98,7 +100,8 @@ explorer.components.container.ContainerService = class {
    */
   moveNext(opt_container) {
     this.move_(
-        angular.bind(arrayUtilSvc, arrayUtilSvc.moveNext), opt_container);
+        angular.bind(this.arrayUtilSvc, this.arrayUtilSvc.moveNext),
+        opt_container);
   };
 
   /**
@@ -110,7 +113,8 @@ explorer.components.container.ContainerService = class {
    */
   moveLast(opt_container) {
     this.move_(
-        angular.bind(arrayUtilSvc, arrayUtilSvc.moveLast), opt_container);
+        angular.bind(this.arrayUtilSvc, this.arrayUtilSvc.moveLast),
+        opt_container);
   };
 
 
@@ -237,7 +241,8 @@ explorer.components.container.ContainerService = class {
     }
 
     this.move_(
-        angular.bind(arrayUtilSvc, arrayUtilSvc.remove), targetContainer);
+        angular.bind(this.arrayUtilSvc, this.arrayUtilSvc.remove),
+        targetContainer);
     delete this.explorerStateSvc.containers.all[targetContainer.model.id];
   }
 };


### PR DESCRIPTION
The bindings were missing "this." prefixes - not sure how this
worked earlier, as far as I can tell there's no implicit "this"
scope for variable references inside class methods. Did this
break as a side effect of different transpilation?

Fixes issue #189.