### PR TITLE
Transpile to ES5_STRICT, use un-minified code.

### DIFF
--- a/client/components/container/container-service.js
+++ b/client/components/container/container-service.js
@@ -241,6 +241,6 @@ explorer.components.container.ContainerService = class {
     delete this.explorerStateSvc.containers.all[targetContainer.model.id];
   }
 };
-const ContainerService = explorer.components.util.ContainerService;
+const ContainerService = explorer.components.container.ContainerService;
 
 });  // goog.scope

--- a/client/components/dashboard/dashboard-service.js
+++ b/client/components/dashboard/dashboard-service.js
@@ -393,7 +393,7 @@ DashboardService.prototype.selectWidget = function(
   }
 
   if (!opt_supressStateChange) {
-    params = {widget: null, container: null};
+    let params = {widget: null, container: null};
 
     if (widget) { params.widget = widget.model.id; }
     if (container) { params.container = container.model.id };
@@ -519,7 +519,7 @@ DashboardService.prototype.selectContainer = function(
   }
 
   if (!opt_supressStateChange) {
-    params = {container: undefined};
+    let params = {container: undefined};
 
     if (widget) { params.widget = widget.model.id; }
     if (container) { params.container = container.model.id };
@@ -794,7 +794,12 @@ DashboardService.prototype.moveWidgetToContainer = function(
   targetContainer.model.container.columns += widget.model.layout.columnspan;
   targetContainer.model.container.children.push(widget);
   widget.state().parent = targetContainer;
-  this.selectedContainer = targetContainer;
+
+  // Move the container selection to the target container. Don't change
+  // widget selection.
+  container.state().selected = false;
+  targetContainer.state().selected = true;
+  this.explorerStateService_.containers.selectedId = targetContainer.model.id;
 
   if (widget.state().datasource) {
     widget.state().datasource.status = ResultsDataStatus.TOFETCH;

--- a/client/components/query_builder/query-builder.js
+++ b/client/components/query_builder/query-builder.js
@@ -271,9 +271,9 @@ QueryBuilder.buildWhereArgs = function(queryProperties) {
   for (let i = 0, iLen = queryProperties.metadataFilters.length;
        i < iLen; i++) {
     let filter = queryProperties.metadataFilters[i];
-    whereRow = [];
+    let whereRow = [];
     for (let j = 0, jLen = filter.filterClauses.length; j < jLen; j++) {
-      filterClause = filter.filterClauses[j];
+      let filterClause = filter.filterClauses[j];
       // TODO: Add support for multiple match_on values and rules
       // that are not placed between filter name and value
       whereRow.push(QueryBuilder.getRegexpForMetadata(filter.fieldName) +

--- a/client/components/widget/query/builder/query-builder-service.js
+++ b/client/components/widget/query/builder/query-builder-service.js
@@ -382,7 +382,7 @@ QueryBuilderService.prototype.getSql = function(
     tableId = projectId + ':' + tableId;
   }
 
-  let tableExpr = '';
+  let tableExpression = '';
 
   if (tablePartition == QueryTablePartitioning.PERDAY) {
     if (!startFilter) {

--- a/client/components/widget/query/data-view-service.js
+++ b/client/components/widget/query/data-view-service.js
@@ -193,7 +193,7 @@ DataViewService.prototype.getSortedColumns = function(dataTable, sortColumnStart
   }
 
   for (let i = 0; i < sortableColumnNames.length; ++i) {
-    sortableIndex = allColumnNames.indexOf(sortableColumnNames[i]);
+    let sortableIndex = allColumnNames.indexOf(sortableColumnNames[i]);
 
     if (sortableIndex == -1) {
       throw 'sortableColumn not found.';

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -29,23 +29,23 @@ gulp.task('third_party', function() {
       .pipe(gulp.dest('deploy/client/third_party/jquery'));
 
   /** Angular */
-  gulp.src('bower_components/angular/angular.min.*')
+  gulp.src('bower_components/angular/angular.*')
     .pipe(gulp.dest('deploy/client/third_party/angular'));
 
-  gulp.src('bower_components/angular-animate/angular-animate.min.*')
+  gulp.src('bower_components/angular-animate/angular-animate.*')
     .pipe(gulp.dest('deploy/client/third_party/angular'));
 
-  gulp.src('bower_components/angular-aria/angular-aria.min.*')
+  gulp.src('bower_components/angular-aria/angular-aria.*')
     .pipe(gulp.dest('deploy/client/third_party/angular'));
 
   gulp.src('bower_components/angular-mocks/angular-mocks.*')
     .pipe(gulp.dest('deploy/client/third_party/angular'));
 
-  gulp.src('bower_components/angular-material/angular-material.min.*')
+  gulp.src('bower_components/angular-material/angular-material.*')
     .pipe(gulp.dest('deploy/client/third_party/angular-material'));
 
   /** Angular UI */
-  gulp.src('bower_components/angular-bootstrap/ui-bootstrap-tpls.min.js')
+  gulp.src('bower_components/angular-bootstrap/ui-bootstrap-tpls*.js')
       .pipe(gulp.dest('deploy/client/third_party/bootstrap-ui'));
 
   gulp.src('bower_components/bootstrap-css-only/css/bootstrap.min.css')
@@ -54,7 +54,7 @@ gulp.task('third_party', function() {
   gulp.src('bower_components/bootstrap-css-only/fonts/*.*')
       .pipe(gulp.dest('deploy/client/third_party/bootstrap-ui/fonts'));
 
-  gulp.src('bower_components/angular-ui-router/release/angular-ui-router.min.js')
+  gulp.src('bower_components/angular-ui-router/release/angular-ui-router*.js')
       .pipe(gulp.dest('deploy/client/third_party/angular-ui-router'));
 
   gulp.src('bower_components/angular-ui-grid/ui-grid.*')
@@ -131,8 +131,9 @@ gulp.task('prod', ['common'], function() {
       compilerFlags: {
         angular_pass: true,
         compilation_level: 'SIMPLE_OPTIMIZATIONS',
+        formatting: 'PRETTY_PRINT',
         language_in: 'ECMASCRIPT6',
-        language_out: 'ECMASCRIPT5',
+        language_out: 'ECMASCRIPT5_STRICT',
         manage_closure_dependencies: true,
         only_closure_dependencies: true,
         process_closure_primitives: true,

--- a/server/perfkit/explorer/handlers/base.py
+++ b/server/perfkit/explorer/handlers/base.py
@@ -31,6 +31,7 @@ import webapp2
 from google.appengine.api import users
 
 from perfkit.common import data_source_config
+from perfkit.common import http_util
 from perfkit.explorer.model import explorer_config
 
 
@@ -90,6 +91,12 @@ class RequestHandlerBase(webapp2.RequestHandler):
     template_values['static_dir'] = ('/_static/%s' %
                                      os.environ['CURRENT_VERSION_ID'])
     template_values['env'] = self.env
+
+    if http_util.GetBoolParam(self.request, 'debug',
+                              os.environ.get('PKE_DEBUG', False)):
+      template_values['min'] = ''
+    else:
+      template_values['min'] = '.min'
 
     if users.get_current_user():
       template_values['current_user_email'] = users.get_current_user().email()

--- a/server/perfkit/explorer/handlers/templates/third-party-scripts.html
+++ b/server/perfkit/explorer/handlers/templates/third-party-scripts.html
@@ -1,20 +1,20 @@
   <!-- JQuery & Angular -->
   <script src="[[static_dir]]/third_party/jquery/jquery.min.js"></script>
-  <script src="[[static_dir]]/third_party/angular/angular.min.js"></script>
-  <script src="[[static_dir]]/third_party/angular/angular-animate.min.js"></script>
-  <script src="[[static_dir]]/third_party/angular/angular-aria.min.js"></script>
+  <script src="[[static_dir]]/third_party/angular/angular[[min]].js"></script>
+  <script src="[[static_dir]]/third_party/angular/angular-animate[[min]].js"></script>
+  <script src="[[static_dir]]/third_party/angular/angular-aria[[min]].js"></script>
   <script src="[[static_dir]]/third_party/angular/angular-mocks.js"></script>
 
   <!-- Angular Material -->
   <link rel="stylesheet" href="[[static_dir]]/third_party/angular-material/angular-material.min.css" />
-  <script src="[[static_dir]]/third_party/angular-material/angular-material.min.js"></script>
+  <script src="[[static_dir]]/third_party/angular-material/angular-material[[min]].js"></script>
   <link type="text/css" rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/font-awesome/4.3.0/css/font-awesome.min.css" />
 
   <!-- AngularUI Router -->
-  <script src="[[static_dir]]/third_party/angular-ui-router/angular-ui-router.min.js"></script>
+  <script src="[[static_dir]]/third_party/angular-ui-router/angular-ui-router[[min]].js"></script>
 
   <!-- AngularUI Grid -->
-  <script src="[[static_dir]]/third_party/ui-grid/ui-grid.js"></script>
+  <script src="[[static_dir]]/third_party/ui-grid/ui-grid[[min]].js"></script>
   <link href="[[static_dir]]/third_party/ui-grid/ui-grid.css" rel="stylesheet">
 
   <!-- CodeMirror3 Editor -->
@@ -24,7 +24,7 @@
   <link href="[[static_dir]]/third_party/codemirror/codemirror.css" rel="stylesheet" />
 
   <!-- Bootstrap & Bootstrap UI -->
-  <script src="[[static_dir]]/third_party/bootstrap-ui/ui-bootstrap-tpls.min.js"></script>
+  <script src="[[static_dir]]/third_party/bootstrap-ui/ui-bootstrap-tpls[[min]].js"></script>
   <link href="[[static_dir]]/third_party/bootstrap-ui/css/bootstrap.min.css" rel="stylesheet" />
 
   <script type="text/javascript" src="//www.google.com/jsapi"></script>


### PR DESCRIPTION
This is initially intended for discussion - the change currently uses un-minified Angular unconditionally,
not sure if that's acceptable for performance.

I've also tried to use the minified version with a source map, this now works for source code locations but not for the renamed variables, making debugging nearly impossible. So I wouldn't recommend that variant.