### PR TITLE
Change cookie domain from googleplex.com to auto

### DIFF
--- a/server/perfkit/explorer/handlers/templates/explorer.html
+++ b/server/perfkit/explorer/handlers/templates/explorer.html
@@ -16,7 +16,7 @@
         m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
     })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
-    ga('create', '[[analytics_key]]', 'googleplex.com');
+    ga('create', '[[analytics_key]]', 'auto');
     ga('send', 'pageview');
 
     // Initialize Google Visualizations


### PR DESCRIPTION
The 'auto' setting will use the current site's domain for the cookie, which is preferable to assuming the current 'googleplex.com' behavior.