### PR TITLE
Revert Angular Material to 10.1, remove CSS workaround

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -7,7 +7,7 @@
   "devDependencies": {
     "angular": "~1.4.7",
     "angular-mocks": "~1.4.7",
-    "angular-material": "~0.11.3",
+    "angular-material": "~0.10.1",
     "angular-ui-router": "~0.2.15",
     "angular-ui-grid": "~3.0.0-rc.22",
     "angular-bootstrap": "~0.14.1",

--- a/client/components/widget/widget-directive.css
+++ b/client/components/widget/widget-directive.css
@@ -15,7 +15,6 @@
   background: #ffffff;
   border: 1px solid #CCC;
   margin: 15px;
-  width: 100%;
 }
 
 .pk-widget-body.pk-widget-no-overflow {


### PR DESCRIPTION
Angular Material v11.x breaks the layout directive, so we will wait for 1.0 (the next release) to update.