### PR TITLE
Container/Widget Header/Footer Sizing

### DIFF
--- a/client/components/container/container-config-directive.css
+++ b/client/components/container/container-config-directive.css
@@ -1,0 +1,45 @@
+.pk-table-entry-grid {
+  margin-bottom: 12px;
+}
+
+.pk-table-entry-grid th {
+  padding: 8px;
+}
+
+.pk-table-entry-grid thead th {
+  padding-left: 13px;
+}
+
+.pk-table-entry-grid tbody th {
+  padding-left: 0;
+  padding-bottom: 4px;
+}
+
+.pk-table-entry-grid tr:not(:last-child) input.form-control {
+  border-bottom: 0;
+}
+
+.pk-table-entry-grid td:not(:last-child) input.form-control {
+  border-right: 0;
+}
+
+.pk-table-entry-grid input.form-control {
+  border-radius: 0;
+}
+
+.pk-table-entry-grid tr:last-child td:nth-child(2) input.form-control {
+  border-bottom-left-radius: 4px;
+}
+
+.pk-table-entry-grid tr:last-child td:last-child input.form-control {
+  border-bottom-right-radius: 4px;
+}
+
+.pk-table-entry-grid tr:first-child td:nth-child(2) input.form-control {
+  border-top-left-radius: 4px;
+}
+
+.pk-table-entry-grid tr:first-child td:last-child input.form-control {
+  border-top-right-radius: 4px;
+}
+

--- a/client/components/container/container-config-directive.html
+++ b/client/components/container/container-config-directive.html
@@ -23,6 +23,54 @@
   </div>
 
   <div class="pk-sidebar-item">
+    <div class="pk-sidebar-item-label">header/footer heights (px)</div>
+    <div class="pk-sidebar-item-value">
+      <style>
+
+      </style>
+      <table class="pk-table-entry-grid">
+        <thead>
+          <tr>
+            <th>&nbsp;</th>
+            <th>container</th>
+            <th>widget</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <th>header</th>
+            <td>
+              <input input type="number" min="0"
+                  class="form-control container-header-height"
+                  ng-model="ngModel.header_height" ng-disabled="!ngModel"
+                  placeholder="stretch">
+            </td>
+            <td>
+              <input input type="number" min="0"
+                  class="form-control container-widget-header-height"
+                  ng-model="ngModel.widget_header_height" ng-disabled="!ngModel"
+                  placeholder="stretch">
+            </td>
+          </tr>
+          <tr>
+            <th>footer</th>
+            <td>
+              <input input type="number" min="0"
+                  class="form-control container-footer-height"
+                  ng-model="ngModel.footer_height" ng-disabled="!ngModel"
+                  placeholder="stretch">
+            </td>
+            <td>
+              <input input type="number" min="0"
+                  class="form-control container-widget-footer-height"
+                  ng-model="ngModel.widget_footer_height" ng-disabled="!ngModel"
+                  placeholder="stretch">
+            </td>
+          </tr>
+        </tbody>
+      </table>
+
+  <div class="pk-sidebar-item">
     <md-tooltip md-direction="right">
       Header text is formatted using "Showdown" markdown.  Click the link for help and details.
     </md-tooltip>

--- a/client/components/container/container-model.js
+++ b/client/components/container/container-model.js
@@ -48,47 +48,35 @@ const Flow = p3rf.perfkit.explorer.components.container.Flow;
 /** @constructor */
 p3rf.perfkit.explorer.components.container.
 ContainerModel = function() {
-  /**
-   * @type {Flow}
-   * @export
-   */
+  /** @export {Flow} */
   this.flow = Flow.ROW;
 
-  /**
-   * @type {number}
-   * @export
-   */
+  /** @export {number} */
   this.columns = 1;
 
-  /**
-   * @type {number}
-   * @export
-   */
+  /** @export {number} */
   this.height = 250;
+
+  /** @export {?number} */
+  this.header_height = null;
+
+  /** @export {string} */
+  this.header_text = '';
+
+  /** @export {?number} */
+  this.footer_height = null;
+
+  /** @export {string} */
+  this.footer_text = '';
+
+  /** @export {Array.<WidgetConfig>} */
+  this.children = [];
 
   /** @export {?number} */
   this.widget_header_height = null;
 
   /** @export {?number} */
   this.widget_footer_height = null;
-
-  /** @export {string} */
-  this.header_text = '';
-
-  /** @export {string} */
-  this.footer_text = '';
-
-  /**
-   * @type {number}
-   * @export
-   */
-  this.height = 250;
-
-  /**
-   * @type {Array.<WidgetConfig>}
-   * @export
-   */
-  this.children = [];
 };
 const ContainerModel = (
     p3rf.perfkit.explorer.components.container.ContainerModel);

--- a/client/components/dashboard/dashboard-directive.html
+++ b/client/components/dashboard/dashboard-directive.html
@@ -40,7 +40,7 @@
               ng-class="{'pk-section-fixed-height': container.model.container.widget_header_height}"
               ng-click="clickWidget($event, widget, container)"
               ng-style="{'height': container.model.container.widget_header_height + 'px'}"
-              markdown-to-html="widget.model.header_text">
+              markdown-to-html="widget.model.header_text || ''">
           </div>
           <div class="pk-widget-content"
                style="min-height: {{ container.model.container.height }}px"
@@ -52,7 +52,7 @@
               ng-class="{'pk-section-fixed-height': container.model.container.widget_footer_height}"
               ng-click="clickWidget($event, widget, container)"
               ng-style="{'height': container.model.container.widget_footer_height + 'px'}"
-              markdown-to-html="widget.model.footer_text">
+              markdown-to-html="widget.model.footer_text || ''">
           </div>
           <div class="pk-widget-footer" ng-show="widget.model.show_statistics"
                ng-click="clickWidget($event, widget, container)">

--- a/client/components/widget/widget-directive.css
+++ b/client/components/widget/widget-directive.css
@@ -30,8 +30,8 @@
 }
 
 .pk-widget-section-text {
-  padding-left: 8px;
-  padding-right: 8px;
+  padding-left: 10px;
+  padding-right: 10px;
 }
 
 .pk-widget-toolbar {


### PR DESCRIPTION
Provides a UX for setting the height of the container or widget's header/footer heights.  If a height is not specified, the section is auto-sized.  If a height is specified, the section will overflow with a scrollable region.