### PR TITLE
Load perfkit_styles.css last to correct override order.

### DIFF
--- a/server/perfkit/explorer/handlers/templates/dashboard-admin.html
+++ b/server/perfkit/explorer/handlers/templates/dashboard-admin.html
@@ -6,8 +6,6 @@
   <base href="/">
 
   <meta name="viewport" content="initial-scale=1, maximum-scale=1" />
-
-  <link type="text/css" rel="stylesheet" href="[[static_dir]]/perfkit_styles.css" />
 </head>
 <body layout="column">
 
@@ -39,5 +37,6 @@
   <script src="[[static_dir]]/perfkit_templates.js"></script>
   <script src="[[static_dir]]/perfkit_scripts.js"></script>
 
+  <link type="text/css" rel="stylesheet" href="[[static_dir]]/perfkit_styles.css" />
 </body>
 </html>

--- a/server/perfkit/explorer/handlers/templates/explorer.html
+++ b/server/perfkit/explorer/handlers/templates/explorer.html
@@ -6,8 +6,6 @@
   <base href="/">
 
   <meta name="viewport" content="initial-scale=1, maximum-scale=1" />
-
-  <link type="text/css" rel="stylesheet" href="[[static_dir]]/perfkit_styles.css" />
 </head>
 <body ng-keydown="explorerCtrl.checkKeyDown($event)" layout="column">
 
@@ -48,5 +46,7 @@
   <!-- Perfkit -->
   <script src="[[static_dir]]/perfkit_templates.js"></script>
   <script src="[[static_dir]]/perfkit_scripts.js"></script>
+
+  <link type="text/css" rel="stylesheet" href="[[static_dir]]/perfkit_styles.css" />
 </body>
 </html>


### PR DESCRIPTION
This is deployed at https://26-1-dot-perfkit-explorer.appspot.com, and fixes an issue with the release that was mis-styling the tab icons and color pickers.