### PR TITLE
gviz status display and animation refactor.

### DIFF
--- a/client/components/widget/data_viz/gviz/gviz-directive.html
+++ b/client/components/widget/data_viz/gviz/gviz-directive.html
@@ -1,14 +1,20 @@
 <div>
-  <div class="pk-chart"
-       ng-show="isChartDisplayed()">
-  </div>
-  <div layout="row" layout-sm="column" layout-align="space-around"
-       class="pk-chart-loading md-primary md-hue-3"
-       ng-show="isLoadingDisplayed()">
-    <md-progress-circular md-mode="indeterminate"></md-progress-circular>
-  </div>
-  <div class="pk-chart-error"
-       ng-show="isErrorDisplayed()">
-    {{ widgetConfig.state().chart.error }}
+  <div class="pk-conditional" ng-class="getWidgetStatusClass()">
+    <div class="pk-if pk-cond-nodata pk-chart-nodata">
+      No data available.
+    </div>
+    <div class="pk-if pk-cond-tofetch pk-chart-queued">
+      <span>
+        z<sup>z<sup>z</sup></sup>
+      </span>
+    </div>
+    <div class="pk-if pk-cond-fetching pk-chart-loading md-primary md-hue-3">
+      <md-progress-circular md-mode="indeterminate"></md-progress-circular>
+    </div>
+    <div class="pk-if pk-cond-fetched pk-chart">
+    </div>
+    <div class="pk-if pk-cond-error pk-chart-error">
+      {{ widgetConfig.state().chart.error }}
+    </div>
   </div>
 </div>

--- a/client/components/widget/data_viz/gviz/gviz-directive.js
+++ b/client/components/widget/data_viz/gviz/gviz-directive.js
@@ -63,6 +63,7 @@ const ResultsDataStatus = explorer.models.ResultsDataStatus;
  *
  * @param {angular.$timeout} $timeout
  * @param {!angular.$location} $location
+ * @param {!angular.$animate} $animate
  * @param {ChartWrapperService} chartWrapperService
  * @param {QueryResultDataService} queryResultDataService
  * @param {*} gvizEvents
@@ -71,7 +72,7 @@ const ResultsDataStatus = explorer.models.ResultsDataStatus;
  * @ngInject
  */
 explorer.components.widget.data_viz.gviz.gvizChart = function(
-    $timeout, $location, chartWrapperService, queryResultDataService,
+    $timeout, $location, $animate, chartWrapperService, queryResultDataService,
     queryBuilderService, gvizEvents, dataViewService, dashboardService,
     errorService, columnStyleService) {
   return {
@@ -85,39 +86,21 @@ explorer.components.widget.data_viz.gviz.gvizChart = function(
       let isDrawing = false;
       // Create and attach to this element a gviz ChartWrapper
       let chartWrapper = chartWrapperService.create();
-      chartWrapper.setContainerId(element[0].children[0]);
+      chartWrapper.setContainerId(element[0].getElementsByClassName('pk-chart')[0]);
 
-      scope.isDataFetching = function() {
-        return scope.widgetConfig.state().datasource.status ===
-            ResultsDataStatus.FETCHING;
-      };
+      // We currently have animations enabled globally thanks to the
+      // material design module, this has the side effect of animating
+      // ng-class, ng-show, and other directives. This seems to be
+      // very broken, resulting in wrong class assignments and other
+      // nasty surprises. Opt out for this class.
+      //
+      // See also: https://github.com/angular/angular.js/issues/3587
+      $animate.enabled(element, false);
 
-      scope.isDataFetched = function() {
-        return scope.widgetConfig.state().datasource.status ===
-            ResultsDataStatus.FETCHED;
-      };
+      scope.ResultsDataStatus = ResultsDataStatus;
 
-      scope.isLoadingDisplayed = function() {
-        let widgetState = scope.widgetConfig.state();
-        return (
-            scope.widgetConfig.model.datasource.query && (
-                widgetState.datasource.status === ResultsDataStatus.FETCHING ||
-                widgetState.datasource.status === ResultsDataStatus.TOFETCH));
-      };
-
-      scope.isChartDisplayed = function() {
-        let widgetState = scope.widgetConfig.state();
-        return (
-            widgetState.datasource.status === ResultsDataStatus.FETCHED &&
-            !widgetState.chart.error);
-      };
-
-      scope.isErrorDisplayed = function() {
-        let widgetState = scope.widgetConfig.state();
-
-        return (
-            widgetState.datasource.status !== ResultsDataStatus.FETCHING &&
-            widgetState.chart.error);
+      scope.getWidgetStatusClass = function() {
+        return 'pk-cond-' + scope.widgetConfig.state().datasource.status.toLowerCase();
       };
 
       let isHeightEnforced = function() {

--- a/client/components/widget/data_viz/gviz/gviz-directive_test.js
+++ b/client/components/widget/data_viz/gviz/gviz-directive_test.js
@@ -64,11 +64,37 @@ describe('gvizDirective', function() {
 
     return {
       component: component,
-      chartDiv: angular.element(component[0].children[0]),
-      errorDiv: angular.element(component[0].children[1]),
-      spinnerDiv: angular.element(component[0].children[2])
+      chartDiv: angular.element(
+          component[0].getElementsByClassName('pk-chart')[0]),
+      errorDiv: angular.element(
+          component[0].getElementsByClassName('pk-chart-error')[0]),
+      spinnerDiv: angular.element(
+          component[0].getElementsByClassName('pk-chart-loading')[0])
     };
   }
+
+  beforeEach(function() {
+    jasmine.addMatchers({
+      toHaveParentState: function() {
+        return {
+          compare: function(actual, expected) {
+            var parentState = actual.parentNode.className.replace(
+                /.*pk-cond-(\S+)/, '$1');
+
+            var result = {};
+            result.pass = (parentState == expected);
+            var elemText = actual.tagName + '(' + actual.className + ')';
+            if (!result.pass) {
+              result.message =
+                  'Expected state "' + expected + '", was "' +
+                  parentState + '".';
+            }
+            return result;
+          }
+        }
+      }
+    });
+  });
 
   beforeEach(module('explorer'));
   beforeEach(module('googleVisualizationMocks'));
@@ -88,22 +114,8 @@ describe('gvizDirective', function() {
     $provide.service('queryResultDataService', queryResultDataService);
   }));
 
-  beforeEach(inject(function($templateCache, $httpBackend) {
-    var template =
-        '<div>' +
-        '<div class="pk-chart"  ng-hide="!isDataFetched()" ng-class=' +
-        '"{\'pk-chart-hidden\': !isChartDisplayed()}">' +
-        '</div>' +
-        '<div class="pk-chart-error" ng-show="' +
-        'widgetConfig.state().chart.error"><div ng-hide="isDataFetching()"' +
-        '> {{widgetConfig.state().chart.error}}</div></div>' +
-        '<div class="spinner" ng-show="isDataFetching()"></div>' +
-        '</div>';
-
+  beforeEach(inject(function($httpBackend) {
     httpBackend = $httpBackend;
-    $templateCache.put(
-        '/static/components/widget/data_viz/gviz/gviz-directive.html',
-        template);
   }));
 
   beforeEach(inject(function($compile, $rootScope, $timeout, GvizChartWrapper,
@@ -243,8 +255,7 @@ describe('gvizDirective', function() {
           state().datasource.status = ResultsDataStatus.FETCHING;
           var component = setupComponent();
 
-          expect(component.spinnerDiv[0].className.split(' '))
-              .not.toContain('ng-hide');
+          expect(component.spinnerDiv[0]).toHaveParentState('fetching');
         }
     );
 
@@ -252,13 +263,11 @@ describe('gvizDirective', function() {
         function() {
           state().datasource.status = ResultsDataStatus.NODATA;
           var component = setupComponent();
-          expect(component.spinnerDiv[0].className.split(' '))
-              .toContain('ng-hide');
+          expect(component.spinnerDiv[0]).toHaveParentState('nodata');
 
           state().datasource.status = ResultsDataStatus.FETCHED;
           rootScope.$apply();
-          expect(component.spinnerDiv[0].className.split(' '))
-              .toContain('ng-hide');
+          expect(component.spinnerDiv[0]).toHaveParentState('fetched');
         }
     );
 
@@ -267,19 +276,7 @@ describe('gvizDirective', function() {
           setupData(true);
           var component = setupComponent();
 
-          expect(component.chartDiv.hasClass('pk-chart-hidden')).
-              toBeFalsy();
-        }
-    );
-
-    it('should hide the chart when there is an error.',
-        function() {
-          setupData();
-          var component = setupComponent();
-          state().chart.error = 'fake error';
-          rootScope.$apply();
-          expect(component.chartDiv.hasClass('pk-chart-hidden')).
-              toBeTruthy();
+          expect(component.chartDiv[0]).toHaveParentState('fetched');
         }
     );
 
@@ -287,8 +284,7 @@ describe('gvizDirective', function() {
         function() {
           setupData(true);
           var component = setupComponent();
-          expect(component.chartDiv[0].className.split(' '))
-              .not.toContain('ng-hide');
+          expect(component.chartDiv[0]).toHaveParentState('fetched');
         }
     );
 
@@ -296,19 +292,7 @@ describe('gvizDirective', function() {
         function() {
           state().datasource.status = ResultsDataStatus.FETCHING;
           var component = setupComponent();
-          expect(component.chartDiv[0].className.split(' '))
-              .toContain('ng-hide');
-        }
-    );
-
-    it('should show the error when there is one.',
-        function() {
-          setupData(true);
-          var component = setupComponent();
-          state().chart.error = 'fake error';
-          rootScope.$apply();
-          expect(component.errorDiv[0].className.split(' '))
-              .not.toContain('ng-hide');
+          expect(component.chartDiv[0]).toHaveParentState('fetching');
         }
     );
 
@@ -316,8 +300,7 @@ describe('gvizDirective', function() {
         function() {
           setupData(true);
           var component = setupComponent();
-          expect(component.errorDiv[0].className.split(' '))
-              .toContain('ng-hide');
+          expect(component.errorDiv[0]).toHaveParentState('fetched');
         }
     );
   });

--- a/client/components/widget/widget-directive.css
+++ b/client/components/widget/widget-directive.css
@@ -88,12 +88,63 @@
   display: none !important;
 }
 
+.pk-chart-loading md-progress-circular {
+  left: 50%;
+  transform: translate(-50%, 0);
+}
+
 .pk-chart-loading .md-left .md-half-circle {
   border-color: #B0BEC5 !important; /** Blue-Grey 200 */
 }
 
 .pk-chart-loading .md-right .md-half-circle {
   border-color: #CFD8DC !important; /** Blue-Grey 100 */
+}
+
+/**
+ * A pk-conditional is used with pk-if children to control visibility.
+ *
+ * The child nodes are invisible (display:none) by default.
+ *
+ * The parent pk-conditional node gets a pk-cond-STATE class set based
+ * on current state, and the child nodes automatically become visible
+ * based on CSS selectors when they match their expected state.
+ */
+.pk-conditional .pk-if {
+  display: none;
+}
+
+/** Configure conditional visibility for gviz-directive child nodes. */
+.pk-conditional.pk-cond-fetched .pk-chart,
+.pk-conditional.pk-cond-tofetch .pk-chart-queued,
+.pk-conditional.pk-cond-fetching .pk-chart-loading,
+.pk-conditional.pk-cond-nodata .pk-chart-nodata,
+.pk-conditional.pk-cond-error .pk-chart-error {
+  display: block;
+}
+
+@keyframes pk-queued-anim {
+  from { color: #cfd8dc }
+  to { color: #b0bec5 }
+}
+
+div.pk-chart-queued {
+  color: grey;
+  margin: 0px;
+  position: relative;
+  height: 50px;
+  animation: pk-queued-anim 0.5s ease-in-out infinite alternate;
+}
+
+.pk-chart-queued span {
+  position: absolute;
+  left: 50%;
+  top: 25px;
+  transform: translate(-50%, 0);
+}
+
+.pk-chart-queued sup {
+  font-size: 120%;
 }
 
 .pk-chart-error {


### PR DESCRIPTION
Make status display conditional using CSS classes, this reduces the amount of
ng-show dependent code in gviz-directive.html.

Also disable animations for gviz chart elements, these were doing horrific
things to logic due to "animating" adding/removing classes so that
states ended up in a weird superposition of states that were meant to be
mutually exclusive.