### PR TITLE
Update GViz charts to v43, remove Timeline & Treemap controls

### DIFF
--- a/client/components/widget/data_viz/gviz/gviz-charts.json
+++ b/client/components/widget/data_viz/gviz/gviz-charts.json
@@ -25,7 +25,5 @@
   {"title": "Stepped Area", "className": "SteppedAreaChart",
    "seriesColor": true},
   {"title": "Table", "className": "Table"},
-  {"title": "Timeline", "className": "Timeline"},
-  {"title": "Tree Map", "className": "TreeMap"},
   {"title": "Word Tree", "className": "WordTree"}
 ]

--- a/server/perfkit/explorer/handlers/templates/dashboard-admin.html
+++ b/server/perfkit/explorer/handlers/templates/dashboard-admin.html
@@ -23,7 +23,7 @@
     }
 
     // Initialize Google Visualizations
-    google.charts.load('42', {packages: ['corechart', 'charteditor']});
+    google.charts.load('43', {packages: ['corechart', 'charteditor']});
     google.charts.setOnLoadCallback(initializeAngular);
     
     var CURRENT_USER_EMAIL = '[[current_user_email]]';

--- a/server/perfkit/explorer/handlers/templates/explorer.html
+++ b/server/perfkit/explorer/handlers/templates/explorer.html
@@ -31,7 +31,7 @@
     }
 
     // Initialize Google Visualizations
-    google.charts.load('42', {packages: [
+    google.charts.load('43', {packages: [
       'corechart', 'charteditor', 'calendar', 'geochart', 'sankey', 'wordtree',
       'annotationchart']});
     google.charts.setOnLoadCallback(initializeAngular);


### PR DESCRIPTION
Timeline and Treemap controls will be re-enabled when an issue with DataView binding has been resolved (gviz bug)