### PR TITLE
Enable compiler warnings, fix type warnings.

### DIFF
--- a/client/components/code_editor/code-editor-controller.js
+++ b/client/components/code_editor/code-editor-controller.js
@@ -53,7 +53,7 @@ const WidgetFactoryService = explorer.components.widget.WidgetFactoryService;
  *
  * @param {!angular.Scope} $scope
  * @param {!DashboardService} dashboardService
- * @param {!ErrorService} explorerService
+ * @param {!ErrorService} errorService
  * @param {!ExplorerService} explorerService
  * @param {!ExplorerStateService} explorerStateService
  * @param {!WidgetFactoryService} widgetFactoryService
@@ -75,7 +75,7 @@ explorer.components.code_editor.CodeEditorCtrl = function(
   /** @export {!ErrorService} */
   this.errorSvc = errorService;
 
-  /** @export {!ExplorerStateSvc} */
+  /** @export {!ExplorerStateService} */
   this.explorerStateSvc = explorerStateService;
 
   /**

--- a/client/components/code_editor/code-editor-settings-model.js
+++ b/client/components/code_editor/code-editor-settings-model.js
@@ -26,7 +26,7 @@ const explorer = p3rf.perfkit.explorer;
 
 /**
  * Constants for the editor modes.
- * @enum
+ * @enum {string}
  * @export
  */
 explorer.components.code_editor.CodeEditorMode = {

--- a/client/components/codemirror/codemirror-directive.js
+++ b/client/components/codemirror/codemirror-directive.js
@@ -85,7 +85,7 @@ explorer.components.codemirror.CodeMirrorDirective = function(
       };
 
       deferCodeMirror = function() {
-        codeMirror = CodeMirror.fromTextArea(elm[0], opts);
+        let codeMirror = CodeMirror.fromTextArea(elm[0], opts);
         codeMirror.on('change', onChange(opts['onChange']));
 
         for (let i = 0, n = events.length, aEvent; i < n; ++i) {

--- a/client/components/config/config-dialog-controller.js
+++ b/client/components/config/config-dialog-controller.js
@@ -32,8 +32,8 @@ const ConfigService = explorer.components.config.ConfigService;
  * See module docstring for more information about purpose and usage.
  *
  * @param {!angular.Scope} $scope
- * @param {!angular.Log} $log
- * @param {!angular.$modalInstance} $modalInstance
+ * @param {!angular.$log} $log
+ * @param {!ui.bootstrap.modalInstance} $modalInstance
  * @constructor
  * @ngInject
  */
@@ -51,7 +51,7 @@ explorer.components.config.ConfigDialogCtrl = function(
   this.log_ = $log;
 
   /**
-   * @type {!angular.$modalInstance}
+   * @type {!ui.bootstrap.modalInstance}
    * @private
    */
   this.modalInstance_ = $modalInstance;

--- a/client/components/config/config-service.js
+++ b/client/components/config/config-service.js
@@ -155,11 +155,10 @@ ConfigService.prototype.getConfigForTesting = function() {
 /**
  * Provides a copy of the object as JSON.
  *
- * @param {?Object} data An object that the properties will be applied to.
  * @return {!Object} A JSON representation of the config properties.
  */
-ConfigService.prototype.toJSON = function(data) {
-  let result = data || {};
+ConfigService.prototype.toJSON = function() {
+  let result = {};
 
   result.default_project = this.default_project;
   result.default_dataset = this.default_dataset;

--- a/client/components/config/config-service.js
+++ b/client/components/config/config-service.js
@@ -38,17 +38,19 @@ const ErrorTypes = explorer.components.error.ErrorTypes;
 
 /**
  * Service that provides model access for the Explorer page at the top-level.
- * @param {!Angular.HttpService} $location
- * @param {!Angular.LocationService} $location
+ * @param {!angular.HttpService} $http
+ * @param {!angular.LocationService} $location
  * @constructor
  * @ngInject
  */
 explorer.components.config.ConfigService = function($http, $location,
     errorService) {
-  /** @private {!Angular.HttpService} */
+  var INITIAL_CONFIG = goog.global['INITIAL_CONFIG'];
+
+  /** @private {!angular.HttpService} */
   this.http_ = $http;
 
-  /** @private {!Angular.LocationService} */
+  /** @private {!angular.LocationService} */
   this.location_ = location;
 
   /** @private {!ErrorService} */
@@ -87,7 +89,7 @@ const ConfigService = explorer.components.config.ConfigService;
 /**
  * Sets properties based on the JSON data received.
  *
- * @param {!object} data A JSON object containing config data.
+ * @param {!Object} data A JSON object containing config data.
  */
 ConfigService.prototype.populate = function(data) {
   if (goog.isDef(data.default_project)) {

--- a/client/components/config/config-service.js
+++ b/client/components/config/config-service.js
@@ -38,8 +38,8 @@ const ErrorTypes = explorer.components.error.ErrorTypes;
 
 /**
  * Service that provides model access for the Explorer page at the top-level.
- * @param {!angular.HttpService} $http
- * @param {!angular.LocationService} $location
+ * @param {!angular.$http} $http
+ * @param {!angular.$location} $location
  * @constructor
  * @ngInject
  */
@@ -47,11 +47,11 @@ explorer.components.config.ConfigService = function($http, $location,
     errorService) {
   var INITIAL_CONFIG = goog.global['INITIAL_CONFIG'];
 
-  /** @private {!angular.HttpService} */
+  /** @private {!angular.$http} */
   this.http_ = $http;
 
-  /** @private {!angular.LocationService} */
-  this.location_ = location;
+  /** @private {!angular.$location} */
+  this.location_ = $location;
 
   /** @private {!ErrorService} */
   this.errorSvc_ = errorService;
@@ -140,7 +140,7 @@ ConfigService.prototype.populate = function(data) {
  * The returned object is a fresh copy, so the caller may modify
  * values as needed.
  *
- * @return {!object} A JSON object containing config data.
+ * @return {!Object} A JSON object containing config data.
  */
 ConfigService.prototype.getConfigForTesting = function() {
   return goog.object.clone({

--- a/client/components/container/container-model.js
+++ b/client/components/container/container-model.js
@@ -107,7 +107,7 @@ goog.inherits(ContainerWidgetModel, WidgetModel);
 /**
  * @constructor
  * @param {!Object} widgetFactoryService
- * @param {?(Object|ContainerWidgetModel)} opt_model JSON or
+ * @param {?(Object|ContainerWidgetModel)=} opt_model JSON or
  *     ContainerWidgetModel.
  * @extends p3rf.perfkit.explorer.models.WidgetConfig
  */

--- a/client/components/container/container-service.js
+++ b/client/components/container/container-service.js
@@ -21,9 +21,16 @@
 
 goog.provide('p3rf.perfkit.explorer.components.container.ContainerService');
 
+goog.require('p3rf.perfkit.explorer.components.container.ContainerWidgetConfig');
+goog.require('p3rf.perfkit.explorer.components.container.ContainerWidgetModel');
+goog.require('p3rf.perfkit.explorer.components.dashboard.DashboardService');
+goog.require('p3rf.perfkit.explorer.components.explorer.ExplorerStateService');
+goog.require('p3rf.perfkit.explorer.components.util.ArrayUtilService');
+
 goog.scope(function() {
 const explorer = p3rf.perfkit.explorer;
-
+const ContainerWidgetConfig = explorer.components.container.ContainerWidgetConfig;
+const ContainerWidgetModel = explorer.components.container.ContainerWidgetModel;
 
 
 /**
@@ -34,13 +41,13 @@ const explorer = p3rf.perfkit.explorer;
  */
 explorer.components.container.ContainerService = class {
   constructor(arrayUtilService, dashboardService, explorerStateService) {
-    /** @export {!ArrayUtilService} */
+    /** @export {!explorer.components.util.ArrayUtilService} */
     this.arrayUtilSvc = arrayUtilService;
 
-    /** @export {!DashboardService} */
+    /** @export {!explorer.components.dashboard.DashboardService} */
     this.dashboardSvc = dashboardService;
 
-    /** @export {!ExplorerStateService} */
+    /** @export {!explorer.components.explorer.ExplorerStateService} */
     this.explorerStateSvc = explorerStateService;
   };
 

--- a/client/components/container/container-toolbar-directive.js
+++ b/client/components/container/container-toolbar-directive.js
@@ -13,6 +13,8 @@
 
 goog.provide('p3rf.perfkit.explorer.components.container.ContainerToolbarDirective');
 
+goog.require('p3rf.perfkit.explorer.components.container.ContainerService');
+goog.require('p3rf.perfkit.explorer.components.dashboard.DashboardService');
 goog.require('p3rf.perfkit.explorer.components.explorer.sidebar.SidebarTabService');
 
 
@@ -34,10 +36,10 @@ goog.scope(function() {
       transclude: false,
       templateUrl: '/static/components/container/container-toolbar-directive.html',
       controller: ['$scope', function($scope) {
-        /** @export {!ContainerService} */
+        /** @export {!explorer.components.container.ContainerService} */
         this.containerSvc = containerService;
 
-        /** @export {!DashboardService} */
+        /** @export {!explorer.components.dashboard.DashboardService} */
         this.dashboardSvc = dashboardService;
 
         /**

--- a/client/components/dashboard/config/dashboard-config-model.js
+++ b/client/components/dashboard/config/dashboard-config-model.js
@@ -35,7 +35,7 @@ goog.scope(function() {
     constructor() {
       /**
        * A dictionary of config models provided by extensions.
-       * @export {{string, {IExplorerExtension}}}
+       * @export {Object.<string, IExplorerExtension>}
        */
       this.ext = {};
     }

--- a/client/components/dashboard/dashboard-controller.js
+++ b/client/components/dashboard/dashboard-controller.js
@@ -23,6 +23,7 @@ goog.provide('p3rf.perfkit.explorer.components.dashboard.DashboardCtrl');
 
 goog.require('p3rf.perfkit.explorer.components.dashboard.DashboardDataService');
 goog.require('p3rf.perfkit.explorer.components.dashboard.DashboardService');
+goog.require('p3rf.perfkit.explorer.components.explorer.sidebar.SidebarTabService');
 goog.require('p3rf.perfkit.explorer.components.widget.WidgetFactoryService');
 
 goog.scope(function() {
@@ -73,7 +74,7 @@ explorer.components.dashboard.DashboardCtrl = function($scope, $state,
    */
   this.widgetFactoryService_ = widgetFactoryService;
 
-  /** @export {!SidebarTabService} */
+  /** @export {!explorer.components.explorer.sidebar.SidebarTabService} */
   this.tabSvc = sidebarTabService;
 
   /**

--- a/client/components/dashboard/dashboard-data-service.js
+++ b/client/components/dashboard/dashboard-data-service.js
@@ -99,8 +99,8 @@ const DashboardDataService = explorer.components.dashboard.DashboardDataService;
  * TODO (joemu): Factor this out to a helper function.
  * @param {!string} endpoint
  * @param {?*=} opt_queryData An object to send encoded in the query string.
- * @param {?goog.uri.QueryData=} opt_postData An object to send as posted data.
- * @return {angular.$q.Promise.<*>} A promise representing the POST request.
+ * @param {?goog.Uri.QueryData=} opt_postData An object to send as posted data.
+ * @return {!angular.$q.Promise.<*>} A promise representing the POST request.
  */
 DashboardDataService.prototype.post = function(
     endpoint, opt_queryData, opt_postData) {
@@ -108,10 +108,11 @@ DashboardDataService.prototype.post = function(
 
   let promise = this.http_.post(
       endpoint,
-      opt_postData && opt_postData.toString(), {
+      opt_postData && opt_postData.toString(),
+      /** @type {angular.$http.Config} */({
         params: opt_queryData || null,
         headers: {'Content-Type': 'application/x-www-form-urlencoded'}
-      });
+      }));
 
   promise.then(angular.bind(this, function(response) {
     deferred.resolve(response);
@@ -130,7 +131,7 @@ DashboardDataService.prototype.post = function(
  * @param {?DashboardInstance} content
  * @param {!string} endpoint
  * @param {string=} opt_id
- * @return {angular.$q.Promise.<DashboardModel>} Dashboard with an id.
+ * @return {!angular.$q.Promise.<DashboardModel>} Dashboard with an id.
  */
 DashboardDataService.prototype.postDashboard = function(content, endpoint,
     opt_id) {
@@ -249,7 +250,7 @@ DashboardDataService.prototype.editOwner = function(
 /**
  * Returns a list of dashboards.
  *
- * @param {bool=} opt_mine If true, limits the list to items owned by the
+ * @param {boolean=} opt_mine If true, limits the list to items owned by the
  *     current user.  This setting is not useful is opt_owner is specified.
  * @param {string=} opt_owner If provided, limits the list to dashboards owned
  *     by the provided email address.

--- a/client/components/dashboard/dashboard-model.js
+++ b/client/components/dashboard/dashboard-model.js
@@ -46,13 +46,13 @@ explorer.components.dashboard.DashboardParam = function(name, value) {
    * @type {string}
    * @export
    */
-  this.name = name || '';
+  this.name = name;
 
   /**
    * @type {string}
    * @export
    */
-  this.value = value || '';
+  this.value = value;
 };
 const DashboardParam = explorer.components.dashboard.DashboardParam;
 

--- a/client/components/dashboard/dashboard-model.js
+++ b/client/components/dashboard/dashboard-model.js
@@ -159,7 +159,7 @@ const DashboardModel = explorer.components.dashboard.DashboardModel;
  * @return {string} An email address if one exists, otherwise an empty string.
  */
 DashboardModel.prototype.getDefaultOwner = function() {
-  return CURRENT_USER_EMAIL;
+  return goog.global['CURRENT_USER_EMAIL'];
 };
 
 

--- a/client/components/dashboard/dashboard-model.js
+++ b/client/components/dashboard/dashboard-model.js
@@ -139,9 +139,9 @@ explorer.components.dashboard.DashboardModel = function() {
    * @export
    */
   this.params = [];
-  
+
   /**
-   * @dict
+   * @type {Object}
    */
   this.config = {
   };

--- a/client/components/dashboard/dashboard-service.js
+++ b/client/components/dashboard/dashboard-service.js
@@ -102,7 +102,7 @@ explorer.components.dashboard.DashboardService = function(arrayUtilService,
   /** @private {!ArrayUtilService} */
   this.arrayUtilService_ = arrayUtilService;
 
-  /** @private {!ArrayUtilService} */
+  /** @private {!ErrorService} */
   this.errorService_ = errorService;
 
   /** @private {!ExplorerStateService} */
@@ -254,11 +254,10 @@ DashboardService.prototype.saveDashboard = function() {
 /**
  * Iterates through the dashboard and applies functions to the contents.
  * @param {!DashboardInstance} dashboard The dashboard config to iterate.
- * @param {?Function(ContainerConfig)} updateContainerFn The function to apply
+ * @param {?function(ContainerConfig)} updateContainerFn The function to apply
  *    to each container.
- * @param {?Function(WidgetConfig)} updateWidgetFn The function to apply to each
+ * @param {?function(WidgetConfig)} updateWidgetFn The function to apply to each
  *    widget.
- * @param updateWidgetFn
  */
 DashboardService.prototype.updateDashboard = function(
     dashboard, updateContainerFn, updateWidgetFn) {
@@ -629,7 +628,7 @@ DashboardService.prototype.refreshWidget = function(widget) {
  * Changes the widget datasource to accept a custom SQL statement.
  *
  * @param {!WidgetConfig} widget
- * @param {!bool} rewrite If true, rewrites the query based on the QueryBuilder
+ * @param {!boolean} rewrite If true, rewrites the query based on the QueryBuilder
  *    settings.  Otherwise, leaves the query as-is.  Defaults to false.
  * @export
  */

--- a/client/components/dashboard/dashboard-service.js
+++ b/client/components/dashboard/dashboard-service.js
@@ -1052,7 +1052,7 @@ DashboardService.prototype.addWriter = function() {
  * @export
  */
 DashboardService.prototype.addParam = function() {
-  this.current.model.params.push(new DashboardParam());
+  this.current.model.params.push(new DashboardParam('', ''));
 };
 
 

--- a/client/components/dashboard/dashboard-service.js
+++ b/client/components/dashboard/dashboard-service.js
@@ -130,10 +130,10 @@ explorer.components.dashboard.DashboardService = function(arrayUtilService,
   /** @private {!angular.$location} */
   this.location_ = $location;
 
-  /** @private {ui.router.$state} */
+  /** @private {!ui.router.$state} */
   this.$state_ = $state;
 
-  /** @private {ui.router.$stateParams} */
+  /** @private {!ui.router.$stateParams} */
   this.$stateParams_ = $stateParams;
 
   /** @export {Array.<!DashboardParam>} */
@@ -440,7 +440,7 @@ DashboardService.prototype.selectWidget = function(
 
 /**
  * Scrolls the specified content element (typically a widget or container) into view.
- * @param {!angular.element} targetElement The element to scroll into view.
+ * @param {!angular.JQLite} targetElement The element to scroll into view.
  */
 DashboardService.prototype.scrollPageElementIntoView = function(targetElement) {
   let contentElement = angular.element(document.getElementsByClassName('pk-page-content'));
@@ -536,7 +536,7 @@ DashboardService.prototype.selectContainer = function(
 /**
  * Rewrites the current widget's query based on the config.
  * @param {!Widget} widget The widget to rewrite the query against.
- * @param {!bool=} replaceParams If true, parameters (%%NAME%%) will be
+ * @param {boolean=} replaceParams If true, parameters (%%NAME%%) will be
  *     replaced with the current param value (from the dashboard or url).
  *     Defaults to false.
  * @return {string} Rewritten query.
@@ -883,7 +883,7 @@ DashboardService.prototype.removeContainer = function(container) {
  * If clicking on a background UI element, unselect the current widget
  * and container, if any.
  *
- * @param {Event} event;
+ * @param {Event} event
  */
 DashboardService.prototype.onDashboardClick = function(event) {
   // Check if this is called from an event handler. In this case, only
@@ -1077,7 +1077,7 @@ DashboardService.prototype.getTablePartition = function(partitionName) {
  * Tokens are identified by strings wrapped in the QueryBuilderService
  * properties TOKEN_START_SYMBOL and TOKEN_END_SYMBOL.
  *
- * @param artifact {string} The string to replace.
+ * @param {string} value The string to replace.
  * @returns {string} A title with tokens replaced with param values.
  * @export
  */

--- a/client/components/dashboard/dashboard-service.js
+++ b/client/components/dashboard/dashboard-service.js
@@ -20,13 +20,17 @@
 
 goog.provide('p3rf.perfkit.explorer.components.dashboard.DashboardService');
 
+goog.require('p3rf.perfkit.explorer.components.error.ErrorModel');
 goog.require('p3rf.perfkit.explorer.components.error.ErrorService');
 goog.require('p3rf.perfkit.explorer.components.error.ErrorTypes');
 goog.require('p3rf.perfkit.explorer.components.config.ConfigService');
 goog.require('p3rf.perfkit.explorer.components.container.ContainerWidgetConfig');
+goog.require('p3rf.perfkit.explorer.components.container.ContainerWidgetModel');
 goog.require('p3rf.perfkit.explorer.components.dashboard.DashboardInstance');
 goog.require('p3rf.perfkit.explorer.components.dashboard.DashboardDataService');
+goog.require('p3rf.perfkit.explorer.components.dashboard.DashboardModel');
 goog.require('p3rf.perfkit.explorer.components.dashboard.DashboardParam');
+goog.require('p3rf.perfkit.explorer.components.dashboard.DashboardVersionService');
 goog.require('p3rf.perfkit.explorer.components.explorer.ExplorerStateService');
 goog.require('p3rf.perfkit.explorer.components.explorer.sidebar.SidebarTabService');
 goog.require('p3rf.perfkit.explorer.components.util.ArrayUtilService');
@@ -74,11 +78,11 @@ const WidgetType = explorer.models.WidgetType;
  * @param {!ConfigService} configService
  * @param {!ExplorerStateService} explorerStateService
  * @param {!SidebarTabService} sidebarTabService
- * @param {!angular.Filter} $filter
- * @param {!angular.Location} $location
- * @param {!angular.RootScope} $rootScope
- * @param {!angular.Timeout} $timeout
- * @param {!angular.Window} $window
+ * @param {!angular.$filter} $filter
+ * @param {!angular.$location} $location
+ * @param {!angular.Scope} $rootScope
+ * @param {!angular.$timeout} $timeout
+ * @param {!angular.$window} $window
  * @constructor
  * @ngInject
  */
@@ -87,13 +91,13 @@ explorer.components.dashboard.DashboardService = function(arrayUtilService,
     queryBuilderService,  dashboardVersionService, configService,
     explorerStateService, sidebarTabService, $filter, $location, $rootScope,
     $timeout, $window, $state, $stateParams) {
-  /** @private {!angular.Filter} */
+  /** @private {!angular.$filter} */
   this.filter_ = $filter;
 
-  /** @private {!angular.RootScope} */
+  /** @private {!angular.Scope} */
   this.rootScope_ = $rootScope;
 
-  /** @private {!angular.Timeout} */
+  /** @private {!angular.$timeout} */
   this.timeout_ = $timeout;
 
   /** @export {!ConfigService} */
@@ -117,19 +121,19 @@ explorer.components.dashboard.DashboardService = function(arrayUtilService,
   /** @private {!DashboardDataService} */
   this.dashboardDataService_ = dashboardDataService;
 
-  /** @private {!DashboardVersionService} */
+  /** @private {!explorer.components.dashboard.DashboardVersionService} */
   this.dashboardVersionService_ = dashboardVersionService;
 
   /** @private {!QueryBuilderService} */
   this.queryBuilderService_ = queryBuilderService;
 
-  /** @private @type {!angular.Location} */
+  /** @private {!angular.$location} */
   this.location_ = $location;
 
-  /** @private @type {!AngularUI.Router.StateService} */
+  /** @private {ui.router.$state} */
   this.$state_ = $state;
 
-  /** @private @type {!AngularUI.Router.StateParamsService} */
+  /** @private {ui.router.$stateParams} */
   this.$stateParams_ = $stateParams;
 
   /** @export {Array.<!DashboardParam>} */
@@ -152,14 +156,14 @@ explorer.components.dashboard.DashboardService = function(arrayUtilService,
   ];
 
   Object.defineProperty(this, 'current', {
-    /** @export {DashboardModel} */
+    /** @export {function(): explorer.components.dashboard.DashboardModel} */
     get: function() {
       return explorerStateService.selectedDashboard;
     }
   });
 
   Object.defineProperty(this, 'containers', {
-    /** @export {!Array.<ContainerWidgetConfig>} */
+    /** @export {function(): ?Array.<ContainerWidgetConfig>} */
     get: function() {
       if (this.current) {
         return this.current.model.children;
@@ -170,20 +174,20 @@ explorer.components.dashboard.DashboardService = function(arrayUtilService,
   });
 
   Object.defineProperty(this, 'selectedWidget', {
-    /** @export {?WidgetConfig} */
+    /** @export {function(): ?WidgetConfig} */
     get: function() {
       return this.explorerStateService_.widgets.selected;
     }
   });
 
   Object.defineProperty(this, 'selectedContainer', {
-    /** @export {?ContainerWidgetModel} */
+    /** @export {function(): ?explorer.components.container.ContainerWidgetModel} */
     get: function() {
       return this.explorerStateService_.containers.selected;
     }
   });
 
-  /** @export {!Array.<!ErrorModel>} */
+  /** @export {!Array.<!explorer.components.error.ErrorModel>} */
   this.errors = [];
 };
 const DashboardService = explorer.components.dashboard.DashboardService;
@@ -254,7 +258,7 @@ DashboardService.prototype.saveDashboard = function() {
 /**
  * Iterates through the dashboard and applies functions to the contents.
  * @param {!DashboardInstance} dashboard The dashboard config to iterate.
- * @param {?function(ContainerConfig)} updateContainerFn The function to apply
+ * @param {?function(ContainerWidgetConfig)} updateContainerFn The function to apply
  *    to each container.
  * @param {?function(WidgetConfig)} updateWidgetFn The function to apply to each
  *    widget.
@@ -436,7 +440,7 @@ DashboardService.prototype.selectWidget = function(
 
 /**
  * Scrolls the specified content element (typically a widget or container) into view.
- * @param {!angular.Element} targetElement The element to scroll into view.
+ * @param {!angular.element} targetElement The element to scroll into view.
  */
 DashboardService.prototype.scrollPageElementIntoView = function(targetElement) {
   let contentElement = angular.element(document.getElementsByClassName('pk-page-content'));
@@ -449,7 +453,7 @@ DashboardService.prototype.scrollPageElementIntoView = function(targetElement) {
 
 /**
  * Scrolls the specified container into view.
- * @param {!ContainerConfig} container
+ * @param {!ContainerWidgetConfig} container
  */
 DashboardService.prototype.scrollContainerIntoView = function(container) {
   let targetElement = angular.element(

--- a/client/components/dashboard/dashboard-version-model.js
+++ b/client/components/dashboard/dashboard-version-model.js
@@ -30,9 +30,12 @@
 
 goog.provide('p3rf.perfkit.explorer.components.dashboard.DashboardVersionModel');
 
+goog.require('p3rf.perfkit.explorer.components.dashboard.DashboardModel');
+
+
 goog.scope(function() {
 const explorer = p3rf.perfkit.explorer;
-
+const DashboardModel = explorer.components.dashboard.DashboardModel;
 
 
 /**

--- a/client/components/dashboard/dashboard-version-model.js
+++ b/client/components/dashboard/dashboard-version-model.js
@@ -53,7 +53,7 @@ explorer.components.dashboard.DashboardVersionModel = function(
   this.version = opt_version || '';
 
   /**
-   * @type {!function(!DashboardModel): !boolean}
+   * @type {?function(!DashboardModel): !boolean}
    * @export
    */
   this.verify = opt_verify || null;

--- a/client/components/dashboard/dashboard-version-service.js
+++ b/client/components/dashboard/dashboard-version-service.js
@@ -73,7 +73,7 @@ const versions = explorer.components.dashboard.versions;
 /**
  * See module docstring for a description of this service.
  *
- * @param {!angular.FilterService} $filter
+ * @param {!angular.$filter} $filter
  * @ngInject
  * @constructor
  */
@@ -93,7 +93,7 @@ explorer.components.dashboard.DashboardVersionService = function($filter) {
   this.currentVersion = this.versions[0];
 
   /**
-   * @type {!Angular.FilterService} $filter
+   * @type {!angular.$filter} $filter
    */
   this.filter_ = $filter;
 };

--- a/client/components/dashboard/versions/dashboard-schema_01.js
+++ b/client/components/dashboard/versions/dashboard-schema_01.js
@@ -30,6 +30,7 @@ goog.require('p3rf.perfkit.explorer.components.dashboard.versions.DashboardVersi
 goog.scope(function() {
   const DashboardVersionUtil = p3rf.perfkit.explorer.components.dashboard.versions.DashboardVersionUtil;
 
+  /** @constructor */
   p3rf.perfkit.explorer.components.dashboard.versions.DashboardSchemaV1 = function() {
     this.version = '1';
   };

--- a/client/components/dashboard/versions/dashboard-schema_02.js
+++ b/client/components/dashboard/versions/dashboard-schema_02.js
@@ -37,6 +37,7 @@ goog.scope(function() {
   const DashboardVersionUtil = p3rf.perfkit.explorer.components.dashboard.versions.DashboardVersionUtil;
   const QueryConfigModel = p3rf.perfkit.explorer.models.perfkit_simple_builder.QueryConfigModel;
 
+  /** @constructor */
   p3rf.perfkit.explorer.components.dashboard.versions.DashboardSchemaV2 = function() {
     this.version = '2';
   };

--- a/client/components/dashboard/versions/dashboard-schema_03.js
+++ b/client/components/dashboard/versions/dashboard-schema_03.js
@@ -34,6 +34,7 @@ goog.scope(function() {
   const DashboardVersionUtil = p3rf.perfkit.explorer.components.dashboard.versions.DashboardVersionUtil;
   const PivotConfigModel = p3rf.perfkit.explorer.models.perfkit_simple_builder.PivotConfigModel;
 
+  /** @constructor */
   p3rf.perfkit.explorer.components.dashboard.versions.DashboardSchemaV3 = function() {
     this.version = '3';
   };

--- a/client/components/dashboard/versions/dashboard-schema_04.js
+++ b/client/components/dashboard/versions/dashboard-schema_04.js
@@ -33,6 +33,7 @@ goog.require('p3rf.perfkit.explorer.components.dashboard.versions.DashboardVersi
 goog.scope(function() {
   const DashboardVersionUtil = p3rf.perfkit.explorer.components.dashboard.versions.DashboardVersionUtil;
 
+  /** @constructor */
   p3rf.perfkit.explorer.components.dashboard.versions.DashboardSchemaV4 = function() {
     this.version = '4';
   };

--- a/client/components/dashboard/versions/dashboard-schema_05.js
+++ b/client/components/dashboard/versions/dashboard-schema_05.js
@@ -30,6 +30,7 @@ goog.require('p3rf.perfkit.explorer.components.dashboard.versions.DashboardVersi
 goog.scope(function() {
   const DashboardVersionUtil = p3rf.perfkit.explorer.components.dashboard.versions.DashboardVersionUtil;
 
+  /** @constructor */
   p3rf.perfkit.explorer.components.dashboard.versions.DashboardSchemaV5 = function() {
     this.version = '5';
   };

--- a/client/components/dashboard/versions/dashboard-schema_06.js
+++ b/client/components/dashboard/versions/dashboard-schema_06.js
@@ -33,6 +33,7 @@ goog.scope(function() {
   const DashboardVersionUtil = explorer.components.dashboard.versions.DashboardVersionUtil;
   const QueryFilterModel = explorer.models.perfkit_simple_builder.QueryFilterModel;
 
+  /** @constructor */
   p3rf.perfkit.explorer.components.dashboard.versions.DashboardSchemaV6 = function() {
     this.version = '6';
   };

--- a/client/components/dashboard/versions/dashboard-schema_07.js
+++ b/client/components/dashboard/versions/dashboard-schema_07.js
@@ -33,6 +33,7 @@ goog.scope(function() {
   const DashboardVersionUtil = explorer.components.dashboard.versions.DashboardVersionUtil;
   const QueryFilterModel = explorer.models.perfkit_simple_builder.QueryFilterModel;
 
+  /** @constructor */
   explorer.components.dashboard.versions.DashboardSchemaV7 = function() {
     this.version = '7';
   };

--- a/client/components/dashboard_admin_page/dashboard-admin-page-controller.js
+++ b/client/components/dashboard_admin_page/dashboard-admin-page-controller.js
@@ -79,7 +79,7 @@ explorer.components.dashboard_admin_page.DashboardAdminPageCtrl = function(
   /** @private @type {DashboardAdminPageService} */
   $scope.pageService = dashboardAdminPageService;
 
-  /** @export @type {DashboardAdminPageService */
+  /** @export @type {DashboardAdminPageService} */
   this.pageService = dashboardAdminPageService;
 
   /**

--- a/client/components/dashboard_admin_page/dashboard-admin-page-controller.js
+++ b/client/components/dashboard_admin_page/dashboard-admin-page-controller.js
@@ -35,7 +35,7 @@ const DashboardDataService = explorer.components.dashboard.DashboardDataService;
 const DashboardModel = explorer.components.dashboard.DashboardModel;
 const DashboardService = explorer.components.dashboard.DashboardService;
 const WidgetFactoryService = explorer.components.widget.WidgetFactoryService;
-
+const DashboardAdminPageService = explorer.components.dashboard_admin_page.DashboardAdminPageService;
 
 
 /**
@@ -43,7 +43,7 @@ const WidgetFactoryService = explorer.components.widget.WidgetFactoryService;
  *
  * @param {!angular.Scope} $scope
  * @param {!angular.$location} $location
- * @param {!angular.$modal} $modal
+ * @param {!ui.bootstrap.modalInstance} $modal
  * @param {DashboardDataService} dashboardDataService
  * @param {PageService} dashboardAdminPageService
  * @constructor
@@ -53,20 +53,17 @@ explorer.components.dashboard_admin_page.DashboardAdminPageCtrl = function(
     $scope, $location, $modal, dashboardDataService, dashboardAdminPageService,
     uiGridSelectionService) {
   /**
-   * @type {!angular.Scope}
-   * @private
+   * @private {!angular.Scope}
    */
   this.scope_ = $scope;
 
   /**
-   * @type {!angular.$location}
-   * @private
+   * @private {!angular.$location}
    */
   this.location_ = $location;
 
   /**
-   * @type {!angular.$modal}
-   * @private
+   * @private {!ui.bootstrap.modalInstance}
    */
   this.modal_ = $modal;
 

--- a/client/components/dashboard_admin_page/dashboard-admin-page-model.js
+++ b/client/components/dashboard_admin_page/dashboard-admin-page-model.js
@@ -28,7 +28,7 @@ const explorer = p3rf.perfkit.explorer;
 /** @constructor */
 explorer.components.dashboard_admin_page.DashboardAdminPageModel = function() {
   /**
-   * @type {bool}
+   * @type {boolean}
    * @export
    */
   this.filter_owner = false;
@@ -40,7 +40,7 @@ explorer.components.dashboard_admin_page.DashboardAdminPageModel = function() {
   this.owner = null;
 
   /**
-   * @type {?bool}
+   * @type {?boolean}
    * @export
    */
   this.mine = null;

--- a/client/components/dashboard_admin_page/dashboard-admin-page-service.js
+++ b/client/components/dashboard_admin_page/dashboard-admin-page-service.js
@@ -26,7 +26,7 @@ goog.require('p3rf.perfkit.explorer.components.dashboard_admin_page.DashboardAdm
 
 goog.scope(function() {
 const explorer = p3rf.perfkit.explorer;
-const dashboardDataService = explorer.components.dashboard.DashboardDataService;
+const DashboardDataService = explorer.components.dashboard.DashboardDataService;
 const PageModel = explorer.components.dashboard_admin_page.DashboardAdminPageModel;
 const DashboardModel = explorer.components.dashboard.DashboardModel;
 
@@ -40,8 +40,7 @@ const DashboardModel = explorer.components.dashboard.DashboardModel;
 explorer.components.dashboard_admin_page.DashboardAdminPageService = function(
     dashboardDataService) {
   /**
-   * @type {Array.<!DashboardModel>}
-   * @export
+   * @export {Array.<!DashboardModel>}
    */
   this.dashboards = [];
 
@@ -50,21 +49,21 @@ explorer.components.dashboard_admin_page.DashboardAdminPageService = function(
 
   /**
    * The selection service is initialized in the gridOptions onRegisterApi.
-   * @export @type {Array.<uiGridSelectionService>}
+   * @export {Array.<uiGridSelectionService>}
    */
   this.selection = null;
 
   /** @private {DashboardDataService} */
   this.dashboardDataService_ = dashboardDataService;
 
-  /** @export @type {!string} */
+  /** @export {!string} */
   this.CURRENT_USER_ADMIN = goog.global['CURRENT_USER_ADMIN'];
 
   /** @export {!boolean} */
   this.isLoading = false;
 
   /**
-   * @type {!DashboardAdminPageModel}
+   * @type {!explorer.components.dashboard_admin_page.DashboardAdminPageModel}
    * @export
    */
   this.model = new PageModel();

--- a/client/components/dashboard_admin_page/dashboard-admin-page-service.js
+++ b/client/components/dashboard_admin_page/dashboard-admin-page-service.js
@@ -58,7 +58,7 @@ explorer.components.dashboard_admin_page.DashboardAdminPageService = function(
   this.dashboardDataService_ = dashboardDataService;
 
   /** @export @type {!string} */
-  this.CURRENT_USER_ADMIN = CURRENT_USER_ADMIN;
+  this.CURRENT_USER_ADMIN = goog.global['CURRENT_USER_ADMIN'];
 
   /** @export {!boolean} */
   this.isLoading = false;

--- a/client/components/dashboard_admin_page/dashboard-upload-dialog-controller.js
+++ b/client/components/dashboard_admin_page/dashboard-upload-dialog-controller.js
@@ -32,29 +32,21 @@ const DashboardInstance = explorer.components.dashboard.DashboardInstance;
  * See module docstring for more information about purpose and usage.
  *
  * @param {!angular.Scope} $scope
- * @param {!angular.Log} $log
- * @param {!angular.$modalInstance} $modalInstance
+ * @param {!angular.$log} $log
+ * @param {!ui.bootstrap.modalInstance} $modalInstance
  * @constructor
  * @ngInject
  */
 explorer.components.dashboard_admin_page.FileUploadDialogCtrl = function(
     $scope, $log, $modalInstance, dashboardDataService, dashboardVersionService,
     dashboardAdminPageService) {
-  /**
-   * @type {!angular.Scope}
-   * @private
-   */
+  /** @private {!angular.Scope} */
   this.scope_ = $scope;
 
-  /** @type {!angular.$log}
-   * @private
-   */
+  /** @private {!angular.$log} */
   this.log_ = $log;
 
-  /**
-   * @type {!angular.$modalInstance}
-   * @private
-   */
+  /** @private {!ui.bootstrap.modalInstance} */
   this.modalInstance_ = $modalInstance;
 
   /** @private */

--- a/client/components/error/error_service.js
+++ b/client/components/error/error_service.js
@@ -78,14 +78,14 @@ const ErrorService = components.error.ErrorService;
  * @param {?string=} opt_errorId The ID of the error message.  It will replace
  *     an error with the same ID.  If not provided, the error is added to the
  *     list unconditionally.
- * @return {ErrorModel} A new or existing ErrorModel.
+ * @return {?ErrorModel} A new or existing ErrorModel, or null if not needed.
  * @export
  */
 ErrorService.prototype.addError = function(errorType, text, opt_errorId) {
   if (goog.isDef(opt_errorId)) {
     if (ErrorTypes.All.indexOf(errorType) >
         ErrorTypes.All.indexOf(this.MAX_ERROR_SEVERITY)) {
-      return;
+      return null;
     }
 
     let existingError = this.filter_('getByProperty')(

--- a/client/components/error/error_service.js
+++ b/client/components/error/error_service.js
@@ -31,20 +31,20 @@ const ErrorTypes = components.error.ErrorTypes;
 
 
 /**
- * @param {!angular.RootScope} $rootScope Provides access to the root scope.
- * @param {!angular.Filter} $filter Angular filter service.
- * @param {!angular.Window} $window Angular window service.
+ * @param {!angular.Scope} $rootScope Provides access to the root scope.
+ * @param {!angular.$filter} $filter Angular filter service.
+ * @param {!angular.$window} $window Angular window service.
  * @ngInject
  * @constructor
  */
 components.error.ErrorService = function($rootScope, $filter, $window) {
-  /** @type {angular.Filter} */
+  /** @private {!angular.$filter} */
   this.filter_ = $filter;
 
-  /** @type {angular.Window} */
+  /** @private {!angular.$window} */
   this.window_ = window;
 
-  /** @type {angular.RootScope} */
+  /** @private {!angular.Scope} */
   this.rootScope_ = $rootScope;
 
   /** @export {!Array.<ErrorModel>} */

--- a/client/components/explorer/explorer-controller.js
+++ b/client/components/explorer/explorer-controller.js
@@ -39,7 +39,7 @@ const SidebarTabService = explorer.components.explorer.sidebar.SidebarTabService
  * Root controller for the Explorer page.
  *
  * @param {!angular.Scope} $scope
- * @param {!angular.Location} $location
+ * @param {!angular.$location} $location
  * @param {DashboardDataService} dashboardDataService
  * @param {DashboardService} dashboardService
  * @param {ExplorerService} explorerService
@@ -52,7 +52,7 @@ explorer.components.explorer.ExplorerCtrl = function(
     dashboardDataService, dashboardService, explorerService,
     sidebarTabService) {
   /**
-   * @type {angular.Location}
+   * @type {angular.$location}
    * @private
    */
   this.location_ = $location;
@@ -101,8 +101,8 @@ explorer.components.explorer.ExplorerCtrl = function(
         if (!this.explorer.model.readOnly == null) {
           this.explorer.model.readOnly = (
               this.dashboard.current.model.id &&
-              owner.email != CURRENT_USER_EMAIL &&
-              !CURRENT_USER_ADMIN);
+              owner.email != goog.global['CURRENT_USER_EMAIL'] &&
+              !goog.global['CURRENT_USER_ADMIN']);
         }
       }));
 

--- a/client/components/explorer/explorer-router-config.js
+++ b/client/components/explorer/explorer-router-config.js
@@ -33,7 +33,7 @@ goog.scope(function() {
   /**
    * Sets up the explorer routing for selection and focus.
    *
-   * @param {!UIRouter.StateProviderService} $stateProvider
+   * @param {!ui.router.$stateProvider} $stateProvider
    * @constructor
    * @ngInject
    */

--- a/client/components/explorer/explorer-service.js
+++ b/client/components/explorer/explorer-service.js
@@ -49,7 +49,7 @@ const ExplorerModel = explorer.components.explorer.ExplorerModel;
  * @param {!ArrayUtilService} arrayUtilService
  * @param {!DashboardDataService} dashboardDataService
  * @param {!DashboardService} dashboardService
- * @param {!Angular.LocationService} $location
+ * @param {!angular.$location} $location
  * @constructor
  * @ngInject
  */
@@ -121,7 +121,7 @@ explorer.components.explorer.ExplorerService = function(
    * @type {!string}
    * @export
    */
-  this.CURRENT_USER_ADMIN = CURRENT_USER_ADMIN;
+  this.CURRENT_USER_ADMIN = goog.global['CURRENT_USER_ADMIN'];
 
   /**
    * @type {Array.<*>}

--- a/client/components/explorer/explorer-service.js
+++ b/client/components/explorer/explorer-service.js
@@ -20,11 +20,15 @@
 goog.provide('p3rf.perfkit.explorer.components.explorer.ExplorerService');
 
 goog.require('p3rf.perfkit.explorer.components.code_editor.CodeEditorMode');
+goog.require('p3rf.perfkit.explorer.components.container.ContainerService');
 goog.require('p3rf.perfkit.explorer.components.dashboard.DashboardInstance');
+goog.require('p3rf.perfkit.explorer.components.dashboard.DashboardDataService');
 goog.require('p3rf.perfkit.explorer.components.dashboard.DashboardModel');
 goog.require('p3rf.perfkit.explorer.components.dashboard.DashboardService');
 goog.require('p3rf.perfkit.explorer.components.error.ErrorService');
 goog.require('p3rf.perfkit.explorer.components.explorer.ExplorerModel');
+goog.require('p3rf.perfkit.explorer.components.explorer.ExplorerStateService');
+goog.require('p3rf.perfkit.explorer.components.explorer.sidebar.SidebarTabService');
 goog.require('p3rf.perfkit.explorer.components.util.ArrayUtilService');
 goog.require('goog.array');
 goog.require('goog.asserts');
@@ -36,12 +40,15 @@ const explorer = p3rf.perfkit.explorer;
 const ArrayUtilService = explorer.components.util.ArrayUtilService;
 const CodeEditorMode = explorer.components.code_editor.CodeEditorMode;
 const DashboardInstance = explorer.components.dashboard.DashboardInstance;
+const ContainerService = explorer.components.container.ContainerService;
+const DashboardDataService = explorer.components.dashboard.DashboardDataService;
 const DashboardModel = explorer.components.dashboard.DashboardModel;
 const DashboardService = explorer.components.dashboard.DashboardService;
 const DashboardVersionService = explorer.components.dashboard.DashboardVersionService;
 const ErrorService = explorer.components.error.ErrorService;
 const ExplorerModel = explorer.components.explorer.ExplorerModel;
-
+const ExplorerStateService = explorer.components.explorer.ExplorerStateService;
+const SidebarTabService = explorer.components.explorer.sidebar.SidebarTabService;
 
 
 /**

--- a/client/components/explorer/explorer-state-model.js
+++ b/client/components/explorer/explorer-state-model.js
@@ -134,13 +134,4 @@ ExplorerStateModel.prototype.add = function(item) {
   }
 };
 
-
-/**
- * Clears the selection and items from the list.
- * @export
- */
-ExplorerStateModel.prototype.clear = function() {
-  this.all = {};
-};
-
 });  // goog.scope

--- a/client/components/explorer/explorer-state-model.js
+++ b/client/components/explorer/explorer-state-model.js
@@ -37,7 +37,7 @@ const ErrorTypes = explorer.components.error.ErrorTypes;
  * selection ID's, and the .selectedId and .selected properties reference
  * this.
  *
- * @param {!AngularUI.StateService} stateService
+ * @param {!ui.router.$state} stateService
  * @param {!ErrorService} errorService
  * @param {string} stateName
  *
@@ -61,7 +61,7 @@ explorer.components.explorer.ExplorerStateModel = function(
    * If no item is selected, returns NULL.
    */
   Object.defineProperty(this, 'selectedId', {
-    /** @type {?string} */
+    /** @type {function(): ?string} */
     get: () => {
       if (stateService.params[stateName]) {
         return stateService.params[stateName];
@@ -78,7 +78,7 @@ explorer.components.explorer.ExplorerStateModel = function(
    * Returns the item matching the selected id.
    */
   Object.defineProperty(this, 'selected', {
-    /** @type {T} */
+    /** @type {function(): T} */
     get: () => {
       if (goog.isDefAndNotNull(this.selectedId)) {
         let selected = this.all[this.selectedId];
@@ -98,7 +98,7 @@ explorer.components.explorer.ExplorerStateModel = function(
    * returns false.
    */
    Object.defineProperty(this, 'selectedIdIsValid', {
-     /** @type {boolean} */
+     /** @type {function(): boolean} */
      get: () => {
        if (!goog.isDefAndNotNull(this.selectedId)) {
          return false;

--- a/client/components/explorer/explorer-state-service.js
+++ b/client/components/explorer/explorer-state-service.js
@@ -22,7 +22,10 @@ goog.provide('p3rf.perfkit.explorer.components.explorer.ExplorerStateService');
 goog.require('p3rf.perfkit.explorer.components.error.ErrorService');
 goog.require('p3rf.perfkit.explorer.components.error.ErrorTypes');
 goog.require('p3rf.perfkit.explorer.components.explorer.ExplorerStateModel');
-
+goog.require('p3rf.perfkit.explorer.components.explorer.sidebar.SidebarTabModel');
+goog.require('p3rf.perfkit.explorer.components.dashboard.DashboardModel');
+goog.require('p3rf.perfkit.explorer.components.container.ContainerWidgetModel');
+goog.require('p3rf.perfkit.explorer.models.WidgetModel');
 
 
 goog.scope(function() {
@@ -30,7 +33,10 @@ const explorer = p3rf.perfkit.explorer;
 const ErrorService = explorer.components.error.ErrorService;
 const ErrorTypes = explorer.components.error.ErrorTypes;
 const ExplorerStateModel = explorer.components.explorer.ExplorerStateModel;
-
+const DashboardModel = explorer.components.dashboard.DashboardModel;
+const ContainerWidgetModel = explorer.components.container.ContainerWidgetModel;
+const WidgetModel = explorer.models.WidgetModel;
+const SidebarTabModel = explorer.components.explorer.sidebar.SidebarTabModel;
 
 /**
  * Service that provides state and content for the Explorer page.
@@ -39,7 +45,7 @@ const ExplorerStateModel = explorer.components.explorer.ExplorerStateModel;
  */
 explorer.components.explorer.ExplorerStateService = function(
     $state, errorService) {
-  /** @export {!AngularUI.State} */
+  /** @export {!ui.router.$state} */
   this.$state = $state;
 
   /** @private {!ErrorService} */
@@ -69,7 +75,7 @@ explorer.components.explorer.ExplorerStateService = function(
 
   /**
    * Provides storage for a list of widget data.
-   * @export {!Dictionary.<string, WidgetDataModel>}
+   * @export {!Object.<string, WidgetDataModel>}
    */
   this.widgetData = {};
 

--- a/client/components/explorer/sidebar/sidebar-tab-service.js
+++ b/client/components/explorer/sidebar/sidebar-tab-service.js
@@ -178,7 +178,7 @@ SidebarTabService.prototype.getFirstWidgetTab = function() {
 
 /**
   * Returns true if the tab should be displayed, otherwise false.
-  * @param {!SidebarTabModel}
+  * @param {!SidebarTabModel} tab
   * @export
   */
 SidebarTabService.prototype.isTabVisible = function(tab) {
@@ -229,7 +229,7 @@ SidebarTabService.prototype.getLastTab = function() {
     }
   }
 
-  console.log('getFirstTab failed: No non-widget tabs available.');
+  throw new Error('getFirstTab failed: No non-widget tabs available.');
 };
 
 

--- a/client/components/explorer/sidebar/sidebar-tab-service.js
+++ b/client/components/explorer/sidebar/sidebar-tab-service.js
@@ -21,11 +21,12 @@ goog.provide('p3rf.perfkit.explorer.components.explorer.sidebar.SIDEBAR_TABS');
 goog.provide('p3rf.perfkit.explorer.components.explorer.sidebar.SidebarTabService');
 
 goog.require('p3rf.perfkit.explorer.components.explorer.sidebar.SidebarTabModel');
-
+goog.require('p3rf.perfkit.explorer.components.explorer.ExplorerStateService');
 
 goog.scope(function() {
 const explorer = p3rf.perfkit.explorer;
 const SidebarTabModel = explorer.components.explorer.sidebar.SidebarTabModel;
+const ExplorerStateService = explorer.components.explorer.ExplorerStateService
 
 
 explorer.components.explorer.sidebar.SIDEBAR_TABS = [

--- a/client/components/explorer/sidebar/sidebar-tabs-directive.js
+++ b/client/components/explorer/sidebar/sidebar-tabs-directive.js
@@ -16,11 +16,13 @@ goog.provide('p3rf.perfkit.explorer.components.explorer.sidebar.SidebarTabsDirec
 
 goog.require('p3rf.perfkit.explorer.components.explorer.sidebar.SidebarTabService');
 goog.require('p3rf.perfkit.explorer.components.explorer.sidebar.SidebarTabModel');
+goog.require('p3rf.perfkit.explorer.components.dashboard.DashboardService');
 
 
 goog.scope(function() {
 const explorer = p3rf.perfkit.explorer;
 const SidebarTabModel = explorer.components.explorer.sidebar.SidebarTabModel;
+const SidebarTabService = explorer.components.explorer.sidebar.SidebarTabService;
 
 
 /**
@@ -37,7 +39,7 @@ explorer.components.explorer.sidebar.SidebarTabsDirective = function() {
     controller: [
         '$scope', 'dashboardService', 'sidebarTabService',
         function($scope, dashboardService, sidebarTabService) {
-      /** @export {!DashboardService} */
+      /** @export {!explorer.components.dashboard.DashboardService} */
       this.dashboardSvc = dashboardService;
 
       /** @export {!SidebarTabService} */

--- a/client/components/explorer/sidebar/sidebar-tabs-directive.js
+++ b/client/components/explorer/sidebar/sidebar-tabs-directive.js
@@ -45,7 +45,7 @@ explorer.components.explorer.sidebar.SidebarTabsDirective = function() {
 
       /**
        * Reacts to a tab being clicked.  It toggles the tab and hides the tooltip.
-       * @param {!SidebarTabModel}
+       * @param {!SidebarTabModel} tab
        * @export
        */
       this.tabClicked = function(tab) {

--- a/client/components/layout/fill-directive.js
+++ b/client/components/layout/fill-directive.js
@@ -38,7 +38,7 @@ const explorer = p3rf.perfkit.explorer;
  * element whenever the page or container is resized, or a 'layoutChanged'
  * event is broadcast.
  *
- * @param {!Angular.RootScope} rootScope The root scope, used to listen for
+ * @param {!angular.Scope} $rootScope The root scope, used to listen for
  *     custom events.
  * @return {Object} Directive definition object.
  * @ngInject

--- a/client/components/layout/resize-directive.js
+++ b/client/components/layout/resize-directive.js
@@ -23,6 +23,9 @@ goog.provide('p3rf.perfkit.explorer.components.layout.ResizeDirective');
 
 goog.require('p3rf.perfkit.explorer.components.layout.ResizeService');
 
+goog.scope(function() {
+const explorer = p3rf.perfkit.explorer;
+const ResizeService = explorer.components.layout.ResizeService;
 
 /**
  * The ResizeDirective is an attribute that adds behavior to the element around
@@ -32,7 +35,7 @@ goog.require('p3rf.perfkit.explorer.components.layout.ResizeService');
  * {!string} resizeElementId The Id of the element to resize.
  *
  * @param {!ResizeService} resizeService
- * @returns {!ResizeDirective}
+ * @returns {!explorer.components.layout.ResizeDirective}
  * @ngInject
  * @export
  * @constructor
@@ -68,3 +71,5 @@ p3rf.perfkit.explorer.components.layout.ResizeDirective = function(
         }
     };
 };
+
+});  // goog.scope

--- a/client/components/layout/resize-service.js
+++ b/client/components/layout/resize-service.js
@@ -38,7 +38,7 @@ goog.scope(function() {
  * ResizeDirection.RIGHT, because the resizer is on the right, and dragging
  * the resizer to the right would make the element larger.
  *
- * @enum
+ * @enum {string}
  */
 p3rf.perfkit.explorer.components.layout.ResizeDirections = {
   LEFT: 'LEFT',
@@ -51,7 +51,7 @@ const ResizeDirections = p3rf.perfkit.explorer.components.layout.ResizeDirection
 
 /**
  * Holds state and behavior for resize-related layout events.
- * @param {!angular.Scope}
+ * @param {!angular.Scope} $rootScope
  * @returns {!ResizeService}
  * @ngInject
  * @export
@@ -104,7 +104,7 @@ const ResizeService = p3rf.perfkit.explorer.components.layout.ResizeService;
  * size of the element being resized.
  *
  * @param {!Element} resizeElement The element being resized.
- * @param {!ResizeDirection} resizeDirection The direction that the
+ * @param {!ResizeDirections} resizeDirection The direction that the
  *     resizeElement is being resized.
  * @param {!Event} event The event args.  The clientX and clientY properties
  *     will be evaluated.

--- a/client/components/multibox/multibox-directive.js
+++ b/client/components/multibox/multibox-directive.js
@@ -272,7 +272,7 @@ explorer.components.multibox.MultiboxDirective = (function($timeout) {
         return (
                 scope.multiboxSelectedOptions.length > 0 &&
                 activeInput === scope.getLastInputElement() &&
-                activeInput &&
+                goog.isDefAndNotNull(activeInput) &&
                 activeInput.value === '');
       };
 

--- a/client/components/query_builder/query-properties.js
+++ b/client/components/query_builder/query-properties.js
@@ -117,7 +117,7 @@ explorer.components.query_builder.Filter.DisplayMode = {
  * @param {explorer.components.query_builder.FilterClause.MatchRule} matchRule
  *     The rule to use when matching.  This rule can expect one or more values
  *     for example between or greater than.
- * @param {?bool=} opt_isFunction Used to indicate matchOn values that are
+ * @param {?boolean=} opt_isFunction Used to indicate matchOn values that are
  *     function calls, and therefore shouldn't be quoted.
  * @constructor
  */

--- a/client/components/util/array-util-service.js
+++ b/client/components/util/array-util-service.js
@@ -52,20 +52,20 @@ ArrayUtilService.prototype.swap = function(array, from, to) {
 /**
  * Returns the first non-null item in the array.
  * @param {Array.<*>} array
- * @param {bool=} required If true, an error will be thrown if no item is found.
+ * @param {boolean=} opt_required If true, an error will be thrown if no item is found.
  *    Defaults to false.
  * @returns {*} The first non-null element in the array.  If no item is found,
  *    either null is returned or an error is raised, depending on the value of
  *    the required param.
  */
-ArrayUtilService.prototype.getFirst = function(array, required) {
+ArrayUtilService.prototype.getFirst = function(array, opt_required) {
   for (let ctr = 0, len = array.length; ctr < len; ++ctr) {
     if (!goog.string.isEmptySafe(array[ctr])) {
       return array[ctr];
     }
   }
 
-  if (required) {
+  if (opt_required) {
     let msg = 'getFirst failed: No non-null item found.';
 
     throw new Error(msg);

--- a/client/components/util/filters.js
+++ b/client/components/util/filters.js
@@ -31,7 +31,7 @@ const explorer = p3rf.perfkit.explorer;
  * @param {!*} property_value
  * @param {!Array<*>} collection
  *
- * @return {boolean}
+ * @return {*}
  */
 explorer.components.util.GetByPropertyFilter = function(
     property_name, property_value, collection) {

--- a/client/components/util/filters.js
+++ b/client/components/util/filters.js
@@ -31,7 +31,7 @@ const explorer = p3rf.perfkit.explorer;
  * @param {!*} property_value
  * @param {!Array<*>} collection
  *
- * @return {bool}
+ * @return {boolean}
  */
 explorer.components.util.GetByPropertyFilter = function(
     property_name, property_value, collection) {

--- a/client/components/util/work-queue-service.js
+++ b/client/components/util/work-queue-service.js
@@ -51,7 +51,7 @@ const WorkQueueService = explorer.components.util.WorkQueueService;
  * The STARTED notification is sent when a work item changes state
  * from "queued" to "executing".
  *
- * @enum{string}
+ * @enum {string}
  */
 WorkQueueService.NOTIFICATION = {
   STARTED: 'Started'

--- a/client/components/widget/data_viz/gviz/chart-wrapper-service.js
+++ b/client/components/widget/data_viz/gviz/chart-wrapper-service.js
@@ -134,7 +134,7 @@ const ChartWrapperService = (
 ChartWrapperService.prototype.loadCharts = function() {
   this.http_.get('/static/components/widget/data_viz/gviz/gviz-charts.json').
       success(angular.bind(this, function(response) {
-        $.merge(this.allCharts, response);
+        goog.array.extend(this.allCharts, response);
         this.allChartsIndex = this.arrayUtilSvc_.getDictionary(
             this.allCharts, 'className');
       })).

--- a/client/components/widget/data_viz/gviz/chart-wrapper-service.js
+++ b/client/components/widget/data_viz/gviz/chart-wrapper-service.js
@@ -23,15 +23,16 @@
 
 goog.provide('p3rf.perfkit.explorer.components.widget.data_viz.gviz.ChartWrapperService');
 
+goog.require('p3rf.perfkit.explorer.components.util.ArrayUtilService');
 goog.require('p3rf.perfkit.explorer.components.widget.data_viz.gviz.getGvizChartWrapper');
 goog.require('p3rf.perfkit.explorer.models.ChartModel');
 goog.require('p3rf.perfkit.explorer.models.ChartType');
 
 goog.scope(function() {
 const explorer = p3rf.perfkit.explorer;
+const ArrayUtilService = explorer.components.util.ArrayUtilService;
 const ChartModel = explorer.models.ChartModel;
 const ChartType = explorer.models.ChartType;
-
 
 
 /**

--- a/client/components/widget/data_viz/gviz/chart-wrapper-service.js
+++ b/client/components/widget/data_viz/gviz/chart-wrapper-service.js
@@ -111,7 +111,7 @@ explorer.components.widget.data_viz.gviz.ChartWrapperService = function($http,
 
   /**
    * Provides an ordered list of charts.
-   * @type {Array<!ChartTypeModel>
+   * @type {Array<!ChartTypeModel>}
    * @export
    */
   this.allCharts = [];

--- a/client/components/widget/data_viz/gviz/column_style/column-style-config-directive.js
+++ b/client/components/widget/data_viz/gviz/column_style/column-style-config-directive.js
@@ -20,10 +20,14 @@
 
 goog.provide('p3rf.perfkit.explorer.components.widget.data_viz.gviz.column_style.ColumnStyleConfigDirective');
 
+goog.require('p3rf.perfkit.explorer.models.ChartWidgetConfig');
+goog.require('p3rf.perfkit.explorer.components.widget.data_viz.gviz.column_style.ColumnStyleService');
 
 goog.scope(function() {
 const explorer = p3rf.perfkit.explorer;
 const gviz = explorer.components.widget.data_viz.gviz;
+const ChartWidgetConfig = explorer.models.ChartWidgetConfig;
+const ColumnStyleService = explorer.components.widget.data_viz.gviz.column_style.ColumnStyleService;
 
 
 /**

--- a/client/components/widget/data_viz/gviz/column_style/column-style-directive.js
+++ b/client/components/widget/data_viz/gviz/column_style/column-style-directive.js
@@ -20,10 +20,16 @@
 
 goog.provide('p3rf.perfkit.explorer.components.widget.data_viz.gviz.column_style.ColumnStyleDirective');
 
+goog.require('p3rf.perfkit.explorer.components.widget.data_viz.gviz.column_style.ColumnStyleModel');
+goog.require('p3rf.perfkit.explorer.components.widget.data_viz.gviz.column_style.ColumnStyleService');
+goog.require('p3rf.perfkit.explorer.models.ChartWidgetConfig');
 
 goog.scope(function() {
 const explorer = p3rf.perfkit.explorer;
 const gviz = explorer.components.widget.data_viz.gviz;
+const ColumnStyleModel = explorer.components.widget.data_viz.gviz.column_style.ColumnStyleModel;
+const ColumnStyleService = explorer.components.widget.data_viz.gviz.column_style.ColumnStyleService;
+const ChartWidgetConfig = explorer.models.ChartWidgetConfig;
 
 
 /**

--- a/client/components/widget/data_viz/gviz/column_style/column-style-service.js
+++ b/client/components/widget/data_viz/gviz/column_style/column-style-service.js
@@ -145,7 +145,7 @@ gviz.column_style.ColumnStyleService = class {
    * columns present in the dataTable.
    *
    * @param {!Array.<ColumnStyleModel>} columns
-   * @param {!google.visualizations.DataTable} dataTable
+   * @param {!google.visualization.DataTable} dataTable
    * @return {!Array.<!ColumnStyleModel>}
    * @export
    */
@@ -188,7 +188,7 @@ gviz.column_style.ColumnStyleService = class {
    * the label for the column, as well as other properties in the future.
    *
    * @param {!Array.<ColumnStyleModel>} columns
-   * @param {!google.visualizations.DataTable} dataTable
+   * @param {!google.visualization.DataTable} dataTable
    * @export
    */
   applyToDataTable(columns, dataTable) {
@@ -338,7 +338,7 @@ gviz.column_style.ColumnStyleService = class {
   /**
    * Returns the index of the DataTable column matching the provided id.
    * @param {string} columnId
-   * @param {!google.visualizations.DataTable} dataTable
+   * @param {!google.visualization.DataTable} dataTable
    * @return {number} The 0-based index of the column, or -1 if not found.
    * @export
    */

--- a/client/components/widget/data_viz/gviz/column_style/column-style-service.js
+++ b/client/components/widget/data_viz/gviz/column_style/column-style-service.js
@@ -20,15 +20,24 @@
 
 goog.provide('p3rf.perfkit.explorer.components.widget.data_viz.gviz.column_style.ColumnStyleService');
 
-goog.require('p3rf.perfkit.explorer.components.widget.data_viz.gviz.column_style.ColumnStyleModel');
+goog.require('p3rf.perfkit.explorer.components.dashboard.DashboardService');
 goog.require('p3rf.perfkit.explorer.components.error.ErrorTypes');
-
+goog.require('p3rf.perfkit.explorer.components.error.ErrorService');
+goog.require('p3rf.perfkit.explorer.components.util.ArrayUtilService');
+goog.require('p3rf.perfkit.explorer.components.widget.data_viz.gviz.column_style.ColumnStyleModel');
+goog.require('p3rf.perfkit.explorer.components.widget.data_viz.gviz.ChartWrapperService');
+goog.require('p3rf.perfkit.explorer.models.ChartWidgetConfig');
 
 goog.scope(function() {
 const explorer = p3rf.perfkit.explorer;
 const gviz = explorer.components.widget.data_viz.gviz;
 const ColumnStyleModel = gviz.column_style.ColumnStyleModel;
+const DashboardService = explorer.components.dashboard.DashboardService;
 const ErrorTypes = explorer.components.error.ErrorTypes;
+const ErrorService = explorer.components.error.ErrorService;
+const ArrayUtilService = explorer.components.util.ArrayUtilService;
+const ChartWrapperService = explorer.components.widget.data_viz.gviz.ChartWrapperService;
+const ChartWidgetConfig = explorer.models.ChartWidgetConfig;
 
 
 /**

--- a/client/components/widget/data_viz/gviz/column_style/column-style-toolbar-directive.js
+++ b/client/components/widget/data_viz/gviz/column_style/column-style-toolbar-directive.js
@@ -13,12 +13,18 @@
 
 goog.provide('p3rf.perfkit.explorer.components.widget.data_viz.gviz.column_style.ColumnStyleToolbarDirective');
 
+goog.require('p3rf.perfkit.explorer.components.util.ArrayUtilService');
 goog.require('p3rf.perfkit.explorer.components.widget.data_viz.gviz.column_style.ColumnStyleService');
-
+goog.require('p3rf.perfkit.explorer.components.dashboard.DashboardService');
+goog.require('p3rf.perfkit.explorer.models.ChartWidgetConfig');
 
 goog.scope(function() {
   const explorer = p3rf.perfkit.explorer;
   const gviz = explorer.components.widget.data_viz.gviz;
+  const ArrayUtilService = explorer.components.util.ArrayUtilService;
+  const ColumnStyleService = gviz.column_style.ColumnStyleService;
+  const DashboardService = explorer.components.dashboard.DashboardService;
+  const ChartWidgetConfig = explorer.models.ChartWidgetConfig;
 
 
   /**

--- a/client/components/widget/data_viz/widget-editor-controller.js
+++ b/client/components/widget/data_viz/widget-editor-controller.js
@@ -31,12 +31,9 @@ goog.require('p3rf.perfkit.explorer.models.ChartWidgetConfig');
 goog.scope(function() {
 const explorer = p3rf.perfkit.explorer;
 const ChartWidgetConfig = explorer.models.ChartWidgetConfig;
-const WidgetEditorService = (
-    explorer.components.widget.data_viz.gviz.WidgetEditorService);
+const WidgetEditorService = explorer.components.widget.data_viz.WidgetEditorService;
 const DashboardService = explorer.components.dashboard.DashboardService;
-const QueryResultDataService = (
-    explorer.components.widget.query.QueryResultDataService);
-
+const QueryResultDataService = explorer.components.widget.query.QueryResultDataService;
 
 
 /**
@@ -53,49 +50,32 @@ const QueryResultDataService = (
 explorer.components.widget.data_viz.WidgetEditorCtrl = function($scope,
     dashboardService, widgetEditorService, queryResultDataService,
     GvizDataTable) {
-  /**
-   * @type {!angular.Scope}
-   * @private
-   */
+  /** @private {!angular.Scope} */
   this.scope_ = $scope;
 
-  /**
-   * @type {!ChartEditorService}
-   * @private
-   */
+  /** @private {!WidgetEditorService} */
   this.widgetEditorService_ = widgetEditorService;
 
-  /**
-   * @type {!QueryResultDataService}
-   * @private
-   */
+  /** @private {!QueryResultDataService} */
   this.queryResultDataService_ = queryResultDataService;
 
-  /**
-   * @type {!function(new:google.visualization.DataTable, ...)}
-   * @private
-   */
+  /** @private {!function(new:google.visualization.DataTable, ...)} */
   this.GvizDataTable_ = GvizDataTable;
 
-  /**
-   * @type {!DashboardService}
-   * @export
-   */
+  /** @export {!DashboardService} */
   this.dashboard = dashboardService;
 
   /**
    * The selected chart in the dashboard.
    *
-   * @type {?ChartWidgetConfig}
-   * @export
+   * @export {?ChartWidgetConfig}
    */
   this.selectedChart = null;
 
   /**
    * Error messages raised by this controller.
    *
-   * @type {!Array.<string>}
-   * @export
+   * @export {!Array.<string>}
    */
   this.errors = [];
 

--- a/client/components/widget/query/builder/query-builder-column-config-directive.js
+++ b/client/components/widget/query/builder/query-builder-column-config-directive.js
@@ -20,12 +20,16 @@
 
 goog.provide('p3rf.perfkit.explorer.components.widget.query.builder.QueryBuilderColumnConfigDirective');
 
+goog.require('p3rf.perfkit.explorer.components.widget.query.QueryEditorService');
+goog.require('p3rf.perfkit.explorer.models.ChartWidgetModel');
 goog.require('p3rf.perfkit.explorer.models.perfkit_simple_builder.FieldResult');
 goog.require('p3rf.perfkit.explorer.models.perfkit_simple_builder.LabelResult');
 
 
 goog.scope(function() {
 const explorer = p3rf.perfkit.explorer;
+const QueryEditorService = explorer.components.widget.query.QueryEditorService;
+const ChartWidgetModel = explorer.models.ChartWidgetModel;
 const FieldResult = explorer.models.perfkit_simple_builder.FieldResult;
 const LabelResult = explorer.models.perfkit_simple_builder.LabelResult;
 

--- a/client/components/widget/query/builder/query-builder-datasource-config-directive.js
+++ b/client/components/widget/query/builder/query-builder-datasource-config-directive.js
@@ -20,12 +20,14 @@
 
 goog.provide('p3rf.perfkit.explorer.components.widget.query.builder.QueryBuilderDatasourceConfigDirective');
 
+goog.require('p3rf.perfkit.explorer.models.ChartWidgetModel');
 goog.require('p3rf.perfkit.explorer.components.config.ConfigService');
 goog.require('p3rf.perfkit.explorer.components.dashboard.DashboardService');
 
 
 goog.scope(function() {
 const explorer = p3rf.perfkit.explorer;
+const ChartWidgetModel = explorer.models.ChartWidgetModel;
 const ConfigService = explorer.components.config.ConfigService;
 const DashboardService = explorer.components.dashboard.DashboardService;
 

--- a/client/components/widget/query/builder/query-builder-filter-config-directive.js
+++ b/client/components/widget/query/builder/query-builder-filter-config-directive.js
@@ -23,6 +23,7 @@ goog.provide('p3rf.perfkit.explorer.components.widget.query.builder.QueryBuilder
 goog.require('p3rf.perfkit.explorer.components.widget.query.picklist.PicklistStates');
 goog.require('p3rf.perfkit.explorer.models.perfkit_simple_builder.DateFilter');
 goog.require('p3rf.perfkit.explorer.models.perfkit_simple_builder.MetadataFilter');
+goog.require('p3rf.perfkit.explorer.models.ChartWidgetModel');
 
 
 goog.scope(function() {
@@ -30,6 +31,8 @@ const explorer = p3rf.perfkit.explorer;
 const DateFilter = explorer.models.perfkit_simple_builder.DateFilter;
 const MetadataFilter = explorer.models.perfkit_simple_builder.MetadataFilter;
 const PicklistStates = explorer.components.widget.query.picklist.PicklistStates;
+const PicklistService = explorer.components.widget.query.picklist.PicklistService;
+const ChartWidgetModel = explorer.models.ChartWidgetModel;
 
 
 /**

--- a/client/components/widget/query/builder/query-builder-service.js
+++ b/client/components/widget/query/builder/query-builder-service.js
@@ -21,6 +21,7 @@
 goog.provide('p3rf.perfkit.explorer.components.widget.query.builder.Aggregation');
 goog.provide('p3rf.perfkit.explorer.components.widget.query.builder.QueryBuilderService');
 
+goog.require('p3rf.perfkit.explorer.components.dashboard.DashboardParam');
 goog.require('p3rf.perfkit.explorer.components.query_builder.Filter');
 goog.require('p3rf.perfkit.explorer.components.query_builder.FilterClause');
 goog.require('p3rf.perfkit.explorer.components.query_builder.QueryBuilder');
@@ -38,6 +39,7 @@ goog.require('p3rf.perfkit.explorer.models.perfkit_simple_builder.QueryTablePart
 goog.scope(function() {
 
 const explorer = p3rf.perfkit.explorer;
+const DashboardParam = explorer.components.dashboard.DashboardParam;
 const DateFilter = explorer.models.perfkit_simple_builder.DateFilter;
 const DateFilterType = explorer.models.perfkit_simple_builder.DateFilterType;
 const Filter = explorer.components.query_builder.Filter;
@@ -77,12 +79,10 @@ const Aggregation = explorer.components.widget.query.builder.Aggregation;
 /**
  * The QueryBuilder service transforms a query model into SQL.
  *
- * @param {!Angular.FilterService} $filter
  * @constructor
  * @ngInject
  */
-explorer.components.widget.query.builder.QueryBuilderService = function(
-    $filter) {
+explorer.components.widget.query.builder.QueryBuilderService = function() {
   /**
    * Specifies the character sequence that precedes parameter tokens.
    * @export {string}

--- a/client/components/widget/query/builder/relative-datepicker-directive.js
+++ b/client/components/widget/query/builder/relative-datepicker-directive.js
@@ -107,7 +107,7 @@ explorer.components.widget.query.builder.RelativeDatepickerDirective = function(
       let changeValue = function(new_val, old_val) {
         if (scope.supressChangeEvents) { return; }
 
-        this.suppressChangeEvents = true;
+        scope.suppressChangeEvents = true;
 
         try {
           let filter_data = scope.relativeDatepickerData;
@@ -124,11 +124,11 @@ explorer.components.widget.query.builder.RelativeDatepickerDirective = function(
                   dateText += $filter('date')(date, ' HH:mm:ss');
                 }
 
-                if (date.getMilliseconds > 0) {
+                if (date.getMilliseconds() > 0) {
                   dateText += $filter('date')(date, '.sss');
                 }
 
-                if (date.getTimezoneOffset > 0) {
+                if (date.getTimezoneOffset() > 0) {
                   dateText += $filter('date')(date, ' Z');
                 }
 
@@ -143,7 +143,7 @@ explorer.components.widget.query.builder.RelativeDatepickerDirective = function(
             }
           }
         } finally {
-          this.suppressChangeEvents = false;
+          scope.suppressChangeEvents = false;
         }
       };
 

--- a/client/components/widget/query/data-view-service.js
+++ b/client/components/widget/query/data-view-service.js
@@ -50,6 +50,8 @@
 
 goog.provide('p3rf.perfkit.explorer.components.widget.query.DataViewService');
 
+goog.require('p3rf.perfkit.explorer.components.widget.data_viz.gviz.column_style.ColumnStyleModel');
+goog.require('p3rf.perfkit.explorer.components.widget.data_viz.gviz.column_style.ColumnStyleService');
 goog.require('p3rf.perfkit.explorer.components.widget.data_viz.gviz.getGvizDataView');
 goog.require('p3rf.perfkit.explorer.models.DataViewModel');
 goog.require('p3rf.perfkit.explorer.models.SortOrder');
@@ -58,6 +60,8 @@ goog.scope(function() {
 const explorer = p3rf.perfkit.explorer;
 const DataViewModel = explorer.models.DataViewModel;
 const SortOrder = explorer.models.SortOrder;
+const ColumnStyleModel = explorer.components.widget.data_viz.gviz.column_style.ColumnStyleModel;
+const ColumnStyleService = explorer.components.widget.data_viz.gviz.column_style.ColumnStyleService;
 
 
 /**

--- a/client/components/widget/query/data-view-service.js
+++ b/client/components/widget/query/data-view-service.js
@@ -88,7 +88,7 @@ const DataViewService = explorer.components.widget.query.DataViewService;
  *
  * @param {!google.visualization.DataTable} dataTable
  * @param {!DataViewModel} model
- * @param {!Array.<!ColumnStyleModel>}
+ * @param {!Array.<!ColumnStyleModel>} columns
  * @return {!(Array.<Object>|{error: {property: string, message: string}})}
  */
 DataViewService.prototype.create = function(dataTable, model, columns) {

--- a/client/components/widget/query/picklist/picklist-service.js
+++ b/client/components/widget/query/picklist/picklist-service.js
@@ -75,7 +75,7 @@ picklist.PicklistModel = class {
     /** @export {!PicklistStates} */
     this.state = PicklistStates.EMPTY;
 
-    /** @export {!Array.{!PicklistItemModel}} */
+    /** @export {!Array.<!PicklistItemModel>} */
     this.items = [];
   }
 }

--- a/client/components/widget/query/query-result-config-directive.js
+++ b/client/components/widget/query/query-result-config-directive.js
@@ -22,12 +22,16 @@ goog.provide('p3rf.perfkit.explorer.components.widget.query.QueryResultConfigDir
 
 goog.require('p3rf.perfkit.explorer.models.perfkit_simple_builder.FieldResult');
 goog.require('p3rf.perfkit.explorer.models.perfkit_simple_builder.LabelResult');
+goog.require('p3rf.perfkit.explorer.models.ChartWidgetConfig');
+goog.require('p3rf.perfkit.explorer.models.ChartWidgetModel');
 
 
 goog.scope(function() {
 const explorer = p3rf.perfkit.explorer;
 const FieldResult = explorer.models.perfkit_simple_builder.FieldResult;
 const LabelResult = explorer.models.perfkit_simple_builder.LabelResult;
+const ChartWidgetConfig = explorer.models.ChartWidgetConfig;
+const ChartWidgetModel = explorer.models.ChartWidgetModel;
 
 
 /**

--- a/client/components/widget/query/query-result-data-service.js
+++ b/client/components/widget/query/query-result-data-service.js
@@ -23,12 +23,14 @@
 
 goog.provide('p3rf.perfkit.explorer.components.widget.query.QueryResultDataService');
 goog.provide('p3rf.perfkit.explorer.components.widget.query.DataTableJson');
+
 goog.require('p3rf.perfkit.explorer.components.config.ConfigService');
 goog.require('p3rf.perfkit.explorer.components.error.ErrorTypes');
 goog.require('p3rf.perfkit.explorer.components.error.ErrorService');
 goog.require('p3rf.perfkit.explorer.components.explorer.ExplorerService');
 goog.require('p3rf.perfkit.explorer.components.explorer.ExplorerStateService');
 goog.require('p3rf.perfkit.explorer.components.util.WorkQueueService');
+goog.require('p3rf.perfkit.explorer.models.WidgetConfig');
 
 
 goog.scope(function() {
@@ -39,7 +41,7 @@ const ErrorService = explorer.components.error.ErrorService;
 const ExplorerService = explorer.components.explorer.ExplorerService;
 const ExplorerStateService = explorer.components.explorer.ExplorerStateService;
 const WorkQueueService = explorer.components.util.WorkQueueService;
-
+const WidgetConfig = explorer.models.WidgetConfig;
 
 
 /**

--- a/client/components/widget/query/query-result-data-service.js
+++ b/client/components/widget/query/query-result-data-service.js
@@ -46,7 +46,7 @@ const WorkQueueService = explorer.components.util.WorkQueueService;
  * See module docstring for more information about purpose and usage.
  *
  * @param {!ExplorerService} explorerService
- * @param {!ExplorerStateService} explorerService
+ * @param {!ExplorerStateService} explorerStateService
  * @param {!ErrorService} errorService
  * @param {!ConfigService} configService
  * @param {!WorkQueueService} workQueueService

--- a/client/components/widget/query/query-result-data-service.js
+++ b/client/components/widget/query/query-result-data-service.js
@@ -243,7 +243,7 @@ QueryResultDataService.prototype.fetchResults = function(widget) {
               ErrorTypes.INFO,
               'Returned ' + this.filter_('number')(rows, 0) + ' records, ' +
               'processing ' + this.filter_('number')(size/1000000, 2) + 'MB ' +
-              'in ' + this.filter_('number')(speed, 2) + ' sec.');
+              'in ' + this.filter_('number')(time, 2) + ' sec.');
         }
 
         let data = response.data.results;

--- a/client/externs.js
+++ b/client/externs.js
@@ -22,16 +22,27 @@
  * @author joemu@google.com (Joe Allan Muharsky)
  */
 
-angular.$httpBackend = function() {};
-angular.$httpBackend.prototype.whenGET = function(a) {};
-angular.$httpBackend.prototype.whenPOST = function(a) {};
-angular.$httpBackend.prototype.passThrough = function() {};
-angular.$httpBackend.prototype.respond = function(a) {};
+var jasmine = {};
+jasmine.createSpy = function() {};
 
+function CodeMirror() {};
 CodeMirror.prototype.setValue = function(a) {};
 
 function history() {}
 history.pushState = function(a, b, c) {};
 
-var CURRENT_USER_ADMIN = null;
-var CURRENT_USER_EMAIL = null;
+// TODO(klausw): not sure why these aren't being picked up automatically.
+// Prevents "Bad type annotation" error for IArrayLike in goog/object/object.js
+
+/**
+ * @interface
+ * @template KEY1, VALUE1
+ */
+function IObject() {}
+
+/**
+ * @interface
+ * @extends {IObject<number, VALUE2>}
+ * @template VALUE2
+ */
+function IArrayLike() {}

--- a/client/externs/angular-1.4-http-promise_templated.js
+++ b/client/externs/angular-1.4-http-promise_templated.js
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2014 The Closure Compiler Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview AngularJS' HTTP promises. This version of the externs file
+ * provides templated promises.
+ * @see https://docs.angularjs.org/api/ng/service/$http
+ * @externs
+ */
+
+/**
+ * Left here for backwards compatibility, but no longer used.
+ *
+ * @typedef {function((string|Object), number,
+ *     function(string=): (string|Object|null), angular.$http.Config)}
+ */
+angular.HttpCallback;
+
+/**
+ * @constructor
+ * @template T
+ */
+angular.$http.Response = function() {};
+
+/** @type {T} */
+angular.$http.Response.prototype.data;
+
+/** @type {number} */
+angular.$http.Response.prototype.status;
+
+/**
+ * @param {string=} name
+ * @return {string|Object}
+ */
+angular.$http.Response.prototype.headers = function(name) {};
+
+/** @type {!angular.$http.Config} */
+angular.$http.Response.prototype.config;
+
+/**
+ * @constructor
+ * @extends {angular.$q.Promise.<!angular.$http.Response.<T>>}
+ * @template T
+ */
+angular.$http.HttpPromise = function() {};
+
+/**
+ * @param {function(T, number, function(string=):
+ *     (string|Object|null), angular.$http.Config)} callback
+ * @return {!angular.$http.HttpPromise.<T>} Promise for chaining.
+ */
+angular.$http.HttpPromise.prototype.success = function(callback) {};
+
+/**
+ * @param {function(?, number, function(string=):
+ *     (string|Object|null), angular.$http.Config)} callback
+ * @return {!angular.$http.HttpPromise.<T>} Promise for chaining.
+ */
+angular.$http.HttpPromise.prototype.error = function(callback) {};

--- a/client/externs/angular-1.4-q_templated.js
+++ b/client/externs/angular-1.4-q_templated.js
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2014 The Closure Compiler Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Externs for the $q service in Angular 1.4
+ * NOTE: Due to a JS compiler bug, any use of a templated class must occur after
+ * the class is defined. Please be careful with the ordering of the classes and
+ * functions.
+ * @see https://docs.angularjs.org/api/ng/service/$q
+ * @externs
+ */
+
+/******************************************************************************
+ * $q Service
+ *****************************************************************************/
+
+/**
+ * @constructor
+ */
+angular.$q = function() {};
+
+/**
+ * @constructor
+ * @template T
+ */
+angular.$q.Promise = function() {};
+
+/**
+ * Apply Type Transformation Language to allow more accurate templated type
+ * definition.
+ * This is copied from <code>goog.Thenable.prototype.then</code>, with the only
+ * difference being the raw type as angular.$q.Promise instead of goog.Promise.
+ *
+ * @param {?(function(this:THIS, T): VALUE)=} opt_onFulfilled
+ * @param {?(function(?): ?)=} opt_onRejected
+ * @param {?(function(?): ?)=} opt_notifyCallback
+ * @return {RESULT}
+ * @template THIS
+ * @template VALUE
+ * @template RESULT := type('angular.$q.Promise',
+ *     cond(isUnknown(VALUE), unknown(),
+ *       mapunion(VALUE, (V) =>
+ *         cond(isTemplatized(V) && sub(rawTypeOf(V), 'IThenable'),
+ *           templateTypeOf(V, 0),
+ *           cond(sub(V, 'angular.$q.Promise'),
+ *              unknown(),
+ *              V)))))
+ *  =:
+ */
+angular.$q.Promise.prototype.then =
+    function(opt_onFulfilled, opt_onRejected, opt_notifyCallback) {};
+
+/**
+ * @param {?function(?)} callback
+ * @return {!angular.$q.Promise.<T>}
+ */
+angular.$q.Promise.prototype.catch = function(callback) {};
+
+/**
+ * @param {?function(?)} callback
+ * @return {!angular.$q.Promise.<T>}
+ */
+angular.$q.Promise.prototype.finally = function(callback) {};
+
+/**
+ * @constructor
+ * @template T
+ */
+angular.$q.Deferred = function() {};
+
+/** @param {T=} opt_value */
+angular.$q.Deferred.prototype.resolve = function(opt_value) {};
+
+/** @param {?=} opt_reason */
+angular.$q.Deferred.prototype.reject = function(opt_reason) {};
+
+/** @param {?=} opt_value */
+angular.$q.Deferred.prototype.notify = function(opt_value) {};
+
+/** @type {!angular.$q.Promise.<T>} */
+angular.$q.Deferred.prototype.promise;
+
+/**
+ * $q.all has different output type based on the input type.
+ * When {@code promise} is an array, the output is an array too: for each item n
+ * in the input array, the corresponding item in the returned array would be the
+ * the same type of n, or if n is a templated $q.Promise, the type of the
+ * resolve value.
+ * When {@code promise} is in form of a record, the output should be also be a
+ * record with the same properties.
+ * When {@code promise} is other forms, the returned type is an Object.
+ *
+ * @param {VALUE} promises
+ * @template VALUE
+ * @return {ALLTYPE}
+ * @template ALLTYPE := type('angular.$q.Promise',
+ *   cond(isUnknown(VALUE), unknown(),
+ *     mapunion(VALUE, (x) =>
+ *       cond(sub(x, 'Array'),
+ *         cond(isTemplatized(x) && sub(rawTypeOf(x), 'IThenable'),
+ *           type('Array', templateTypeOf(x, 0)),
+ *           'Array'
+ *         ),
+ *         cond(isRecord(x),
+ *           maprecord(record(x), (kx, vx) => record({[kx]:
+ *             cond(isTemplatized(vx) && sub(rawTypeOf(vx), 'IThenable'),
+ *               templateTypeOf(vx, 0),
+ *               cond(sub(vx, 'angular.$q.Promise'),
+ *                 unknown(),
+ *                 vx
+ *               )
+ *             )
+ *           })),
+ *           'Object')))))
+ * =:
+ */
+angular.$q.prototype.all = function(promises) {};
+
+/**
+ * @return {!angular.$q.Deferred}
+ */
+angular.$q.prototype.defer = function() {};
+
+/**
+ * @param {?=} opt_reason
+ * @return {!angular.$q.Promise}
+ */
+angular.$q.prototype.reject = function(opt_reason) {};
+
+/**
+ * @param {RESULT} value
+ * @return {!angular.$q.Promise.<RESULT>}
+ * @template RESULT
+ */
+angular.$q.prototype.when = function(value) {};

--- a/client/externs/angular-1.4.js
+++ b/client/externs/angular-1.4.js
@@ -1,0 +1,2470 @@
+/*
+ * Copyright 2012 The Closure Compiler Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Externs for Angular 1.
+ *
+ * TODO: Mocks.
+ * TODO: Remaining Services:
+ *     $cookieStore
+ *     $document
+ *     $httpBackend
+ *     $locale
+ *     $rootElement
+ *     $rootScope
+ *     $rootScopeProvider
+ *
+ * TODO: Resolve two issues with angular.$http
+ *         1) angular.$http isn't declared as a
+ *            callable type. It should be declared as a function, and properties
+ *            added following the technique used by $timeout, $parse and
+ *            $interval.
+ *         2) angular.$http.delete cannot be added as an extern
+ *            as it is a reserved keyword.
+ *            Its use is potentially not supported in IE.
+ *            It may be aliased as 'remove' in a future version.
+ *
+ * @see http://angularjs.org/
+ * @externs
+ */
+
+/**
+ * @typedef {(Window|Document|Element|Array.<Element>|string|!angular.JQLite|
+ *     NodeList|{length: number})}
+ */
+var JQLiteSelector;
+
+/**
+ * @const
+ */
+var angular = {};
+
+/**
+ * @param {T} self Specifies the object which this should point to when the
+ *     function is run.
+ * @param {?function(this:T, ...)} fn A function to partially apply.
+ * @return {!Function} A partially-applied form of the function bind() was
+ *     invoked as a method of.
+ * @param {...*} args Additional arguments that are partially applied to the
+ *     function.
+ * @template T
+ */
+angular.bind = function(self, fn, args) {};
+
+/** @typedef {{strictDi: (boolean|undefined)}} */
+angular.BootstrapOptions;
+
+/**
+ * @param {Element|HTMLDocument} element
+ * @param {Array.<string|Function>=} opt_modules
+ * @param {angular.BootstrapOptions=} opt_config
+ * @return {!angular.$injector}
+ */
+angular.bootstrap = function(element, opt_modules, opt_config) {};
+
+/**
+ * @param {T} source
+ * @param {(Object|Array)=} opt_dest
+ * @return {T}
+ * @template T
+ */
+angular.copy = function(source, opt_dest) {};
+
+/**
+ * @param {(JQLiteSelector|Object)} element
+ * @param {(JQLiteSelector|Object)=} opt_context
+ * @return {!angular.JQLite}
+ */
+angular.element = function(element, opt_context) {};
+
+/**
+ * @param {*} o1
+ * @param {*} o2
+ * @return {boolean}
+ */
+angular.equals = function(o1, o2) {};
+
+/**
+ * @param {Object} dest
+ * @param {...Object} srcs
+ */
+angular.extend = function(dest, srcs) {};
+
+/**
+ * @param {Object|Array} obj
+ * @param {Function} iterator
+ * @param {Object=} opt_context
+ * @return {Object|Array}
+ */
+angular.forEach = function(obj, iterator, opt_context) {};
+
+/**
+ * @param {string|T} json
+ * @return {Object|Array|Date|T}
+ * @template T
+ */
+angular.fromJson = function(json) {};
+
+/**
+ * @param {*} arg
+ * @return {*}
+ */
+angular.identity = function(arg) {};
+
+/**
+ * @param {Array.<string|Function>} modules
+ * @return {!angular.$injector}
+ */
+angular.injector = function(modules) {};
+
+/**
+ * @param {*} value
+ * @return {boolean}
+ */
+angular.isArray = function(value) {};
+
+/**
+ * @param {*} value
+ * @return {boolean}
+ */
+angular.isDate = function(value) {};
+
+/**
+ * @param {*} value
+ * @return {boolean}
+ */
+angular.isDefined = function(value) {};
+
+/**
+ * @param {*} value
+ * @return {boolean}
+ */
+angular.isElement = function(value) {};
+
+/**
+ * @param {*} value
+ * @return {boolean}
+ */
+angular.isFunction = function(value) {};
+
+/**
+ * @param {*} value
+ * @return {boolean}
+ */
+angular.isNumber = function(value) {};
+
+/**
+ * @param {*} value
+ * @return {boolean}
+ */
+angular.isObject = function(value) {};
+
+/**
+ * @param {*} value
+ * @return {boolean}
+ */
+angular.isString = function(value) {};
+
+/**
+ * @param {*} value
+ * @return {boolean}
+ */
+angular.isUndefined = function(value) {};
+
+/**
+ * @param {string} s
+ * @return {string}
+ */
+angular.lowercase = function(s) {};
+
+/**
+ * @param {Object} dest
+ * @param {...Object} srcs
+ */
+angular.merge = function(dest, srcs) {};
+
+angular.mock = {};
+
+/**
+ * @param {string} name
+ * @param {Array.<string>=} opt_requires
+ * @param {angular.Injectable=} opt_configFn
+ * @return {!angular.Module}
+ */
+angular.module = function(name, opt_requires, opt_configFn) {};
+
+angular.noop = function() {};
+
+/**
+ * @param {Object|Array|Date|string|number} obj
+ * @param {boolean=} opt_pretty
+ * @return {string}
+ */
+angular.toJson = function(obj, opt_pretty) {};
+
+/**
+ * @param {string} s
+ * @return {string}
+ */
+angular.uppercase = function(s) {};
+
+/**
+ * @typedef {{
+ *   animate: (function(!angular.JQLite, !Object, !Object, !Function,
+ *       !Object=):(!Function|undefined)|undefined),
+ *   enter: (function(!angular.JQLite, !Function, !Object=):
+ *       (!Function|undefined)|undefined),
+ *   leave: (function(!angular.JQLite, !Function, !Object=):
+ *       (!Function|undefined)|undefined),
+ *   move: (function(!angular.JQLite, !Function, !Object=):
+ *       (!Function|undefined)|undefined),
+ *   beforeAddClass: (function(!angular.JQLite, string, !Function, !Object=):
+ *       (!Function|undefined)|undefined),
+ *   addClass: (function(!angular.JQLite, string, !Function, !Object=):
+ *       (!Function|undefined)|undefined),
+ *   beforeRemoveClass: (function(!angular.JQLite, string, !Function, !Object=):
+ *       (!Function|undefined)|undefined),
+ *   removeClass: (function(!angular.JQLite, string, !Function, !Object=):
+ *       (!Function|undefined)|undefined),
+ *   beforeSetClass: (function(!angular.JQLite, string, string, !Function,
+ *       !Object=):(!Function|undefined)|undefined),
+ *   setClass: (function(!angular.JQLite, string, string, !Function, !Object=):
+ *       (!Function|undefined)|undefined)
+ *   }}
+ */
+angular.Animation;
+
+/**
+ * @param {!angular.JQLite} element
+ * @param {!Object} from
+ * @param {!Object} to
+ * @param {!Function} doneFn
+ * @param {!Object=} opt_options
+ * @return {(!Function|undefined)}
+ */
+angular.Animation.animate =
+    function(element, from, to, doneFn, opt_options) {};
+
+/**
+ * @param {!angular.JQLite} element
+ * @param {!Function} doneFn
+ * @param {!Object=} opt_options
+ * @return {(!Function|undefined)}
+ */
+angular.Animation.enter = function(element, doneFn, opt_options) {};
+
+/**
+ * @param {!angular.JQLite} element
+ * @param {!Function} doneFn
+ * @param {!Object=} opt_options
+ * @return {(!Function|undefined)}
+ */
+angular.Animation.leave = function(element, doneFn, opt_options) {};
+
+/**
+ * @param {!angular.JQLite} element
+ * @param {!Function} doneFn
+ * @param {!Object=} opt_options
+ * @return {(!Function|undefined)}
+ */
+angular.Animation.move = function(element, doneFn, opt_options) {};
+
+/**
+ * @param {!angular.JQLite} element
+ * @param {string} className
+ * @param {!Function} doneFn
+ * @param {!Object=} opt_options
+ * @return {(!Function|undefined)}
+ */
+angular.Animation.beforeAddClass =
+    function(element, className, doneFn, opt_options) {};
+
+/**
+ * @param {!angular.JQLite} element
+ * @param {string} className
+ * @param {!Function} doneFn
+ * @param {!Object=} opt_options
+ * @return {(!Function|undefined)}
+ */
+angular.Animation.addClass =
+    function(element, className, doneFn, opt_options) {};
+
+/**
+ * @param {!angular.JQLite} element
+ * @param {string} className
+ * @param {!Function} doneFn
+ * @param {!Object=} opt_options
+ * @return {(!Function|undefined)}
+ */
+angular.Animation.beforeRemoveClass =
+    function(element, className, doneFn, opt_options) {};
+
+/**
+ * @param {!angular.JQLite} element
+ * @param {string} className
+ * @param {!Function} doneFn
+ * @param {!Object=} opt_options
+ * @return {(!Function|undefined)}
+ */
+angular.Animation.removeClass =
+    function(element, className, doneFn, opt_options) {};
+
+/**
+ * @param {!angular.JQLite} element
+ * @param {string} addedClass
+ * @param {string} removedClass
+ * @param {!Function} doneFn
+ * @param {!Object=} opt_options
+ * @return {(!Function|undefined)}
+ */
+angular.Animation.beforeSetClass =
+    function(element, addedClass, removedClass, doneFn, opt_options) {};
+
+/**
+ * @param {!angular.JQLite} element
+ * @param {string} addedClass
+ * @param {string} removedClass
+ * @param {!Function} doneFn
+ * @param {!Object=} opt_options
+ * @return {(!Function|undefined)}
+ */
+angular.Animation.setClass =
+    function(element, addedClass, removedClass, doneFn, opt_options) {};
+
+/**
+ * @constructor
+ */
+angular.Attributes = function() {};
+
+/**
+ * @type {Object.<string, string>}
+ */
+angular.Attributes.prototype.$attr;
+
+/**
+ * @param {string} classVal
+ */
+angular.Attributes.prototype.$addClass = function(classVal) {};
+
+/**
+ * @param {string} classVal
+ */
+angular.Attributes.prototype.$removeClass = function(classVal) {};
+
+/**
+ * @param {string} newClasses
+ * @param {string} oldClasses
+ */
+angular.Attributes.prototype.$updateClass = function(newClasses, oldClasses) {};
+
+/**
+ * @param {string} name
+ * @return {string}
+ */
+angular.Attributes.prototype.$normalize = function(name) {};
+
+/**
+ * @param {string} key
+ * @param {function(*)} fn
+ * @return {function()}
+ */
+angular.Attributes.prototype.$observe = function(key, fn) {};
+
+/**
+ * @param {string} key
+ * @param {?(string|boolean)} value
+ * @param {boolean=} opt_writeAttr
+ * @param {string=} opt_attrName
+ */
+angular.Attributes.prototype.$set =
+    function(key, value, opt_writeAttr, opt_attrName) {};
+
+/**
+ * @typedef {{
+ *   pre: (function(
+ *           !angular.Scope=,
+ *           !angular.JQLite=,
+ *           !angular.Attributes=,
+ *           (!Object|!Array.<!Object>)=)|
+ *       undefined),
+ *   post: (function(
+ *           !angular.Scope=,
+ *           !angular.JQLite=,
+ *           !angular.Attributes=,
+ *           (!Object|Array.<!Object>)=)|
+ *       undefined)
+ *   }}
+ */
+angular.LinkingFunctions;
+
+/**
+ * @param {!angular.Scope=} scope
+ * @param {!angular.JQLite=} iElement
+ * @param {!angular.Attributes=} iAttrs
+ * @param {(!Object|!Array.<!Object>)=} controller
+ */
+angular.LinkingFunctions.pre = function(scope, iElement, iAttrs, controller) {};
+
+/**
+ * @param {!angular.Scope=} scope
+ * @param {!angular.JQLite=} iElement
+ * @param {!angular.Attributes=} iAttrs
+ * @param {(!Object|!Array.<!Object>)=} controller
+ */
+angular.LinkingFunctions.post = function(scope, iElement, iAttrs, controller) {
+};
+
+/**
+ * @typedef {{
+ *   bindToController: (boolean|!Object<string, string>|undefined),
+ *   compile: (function(
+ *       !angular.JQLite=, !angular.Attributes=, Function=)|undefined),
+ *   controller: (angular.Injectable|string|undefined),
+ *   controllerAs: (string|undefined),
+ *   link: (function(
+ *       !angular.Scope=, !angular.JQLite=, !angular.Attributes=,
+ *       (!Object|!Array.<!Object>)=)|
+ *       !angular.LinkingFunctions|
+ *       undefined),
+ *   name: (string|undefined),
+ *   priority: (number|undefined),
+ *   replace: (boolean|undefined),
+ *   require: (string|Array.<string>|undefined),
+ *   restrict: (string|undefined),
+ *   scope: (boolean|Object.<string, string>|undefined),
+ *   template: (string|
+ *       function(!angular.JQLite=,!angular.Attributes=): string|
+ *       undefined),
+ *   templateNamespace: (string|undefined),
+ *   templateUrl: (string|
+ *       function(!angular.JQLite=,!angular.Attributes=)|
+ *       undefined),
+ *   terminal: (boolean|undefined),
+ *   transclude: (boolean|string|undefined)
+ *   }}
+ */
+angular.Directive;
+
+/**
+ * @typedef {(Function|Array.<string|Function>)}
+ */
+angular.Injectable;
+
+/**
+ * @constructor
+ */
+angular.JQLite = function() {};
+
+/**
+ * @param {string} name
+ * @return {!angular.JQLite}
+ */
+angular.JQLite.prototype.addClass = function(name) {};
+
+/**
+ * @param {JQLiteSelector} element
+ * @return {!angular.JQLite}
+ */
+angular.JQLite.prototype.after = function(element) {};
+
+/**
+ * @param {JQLiteSelector} element
+ * @return {!angular.JQLite}
+ */
+angular.JQLite.prototype.append = function(element) {};
+
+/**
+ * @param {string} name
+ * @param {(string|boolean)=} opt_value
+ * @return {!angular.JQLite|string|boolean}
+ */
+angular.JQLite.prototype.attr = function(name, opt_value) {};
+
+/**
+ * @param {string} type
+ * @param {Function} fn
+ * @return {!angular.JQLite}
+ */
+angular.JQLite.prototype.bind = function(type, fn) {};
+
+/**
+ * @return {!angular.JQLite}
+ */
+angular.JQLite.prototype.children = function() {};
+
+/**
+ * @return {!angular.JQLite}
+ */
+angular.JQLite.prototype.clone = function() {};
+
+/**
+ * @return {!angular.JQLite}
+ */
+angular.JQLite.prototype.contents = function() {};
+
+/**
+ * @param {string=} opt_name
+ * @return {Object}
+ */
+angular.JQLite.prototype.controller = function(opt_name) {};
+
+/**
+ * @param {(string|!Object)} nameOrObject
+ * @param {string=} opt_value
+ * @return {!angular.JQLite|string}
+ */
+angular.JQLite.prototype.css = function(nameOrObject, opt_value) {};
+
+/**
+ * @param {string=} opt_key
+ * @param {*=} opt_value
+ * @return {*}
+ */
+angular.JQLite.prototype.data = function(opt_key, opt_value) {};
+
+/**
+ * @return {!angular.JQLite}
+ */
+angular.JQLite.prototype.detach = function() {};
+
+/**
+ * @return {!angular.JQLite}
+ */
+angular.JQLite.prototype.empty = function() {};
+
+/**
+ * @param {number} index
+ * @return {!angular.JQLite}
+ */
+angular.JQLite.prototype.eq = function(index) {};
+
+/**
+ * @param {string} selector
+ * @return {!angular.JQLite}
+ */
+angular.JQLite.prototype.find = function(selector) {};
+
+/**
+ * @param {string} name
+ * @return {boolean}
+ */
+angular.JQLite.prototype.hasClass = function(name) {};
+
+/**
+ * @param {string=} opt_value
+ * @return {!angular.JQLite|string}
+ */
+angular.JQLite.prototype.html = function(opt_value) {};
+
+/**
+ * @param {string=} opt_key
+ * @param {*=} opt_value
+ * @return {*}
+ */
+angular.JQLite.prototype.inheritedData = function(opt_key, opt_value) {};
+
+/**
+ * @return {!angular.$injector}
+ */
+angular.JQLite.prototype.injector = function() {};
+
+/** @type {number} */
+angular.JQLite.prototype.length;
+
+/**
+ * @return {!angular.JQLite}
+ */
+angular.JQLite.prototype.next = function() {};
+
+/**
+ * @param {string} type
+ * @param {Function} fn
+ * @return {!angular.JQLite}
+ */
+angular.JQLite.prototype.on = function(type, fn) {};
+
+/**
+ * @param {string} events
+ * @param {Object|function(Event)} dataOrHandler
+ * @param {function(Event)=} opt_handler
+ */
+angular.JQLite.prototype.one = function(events, dataOrHandler, opt_handler) {};
+
+/**
+ * @param {string=} opt_type
+ * @param {Function=} opt_fn
+ * @return {!angular.JQLite}
+ */
+angular.JQLite.prototype.off = function(opt_type, opt_fn) {};
+
+/**
+ * @return {!angular.JQLite}
+ */
+angular.JQLite.prototype.parent = function() {};
+
+/**
+ * @param {JQLiteSelector} element
+ * @return {!angular.JQLite}
+ */
+angular.JQLite.prototype.prepend = function(element) {};
+
+/**
+ * @param {string} name
+ * @param {*=} opt_value
+ * @return {*}
+ */
+angular.JQLite.prototype.prop = function(name, opt_value) {};
+
+/**
+ * @param {Function} fn
+ * @return {!angular.JQLite}
+ */
+angular.JQLite.prototype.ready = function(fn) {};
+
+/**
+ * @return {!angular.JQLite}
+ */
+angular.JQLite.prototype.remove = function() {};
+
+/**
+ * @param {string} name
+ * @return {!angular.JQLite}
+ */
+angular.JQLite.prototype.removeAttr = function(name) {};
+
+/**
+ * @param {string} name
+ * @return {!angular.JQLite}
+ */
+angular.JQLite.prototype.removeClass = function(name) {};
+
+/**
+ * @param {string=} opt_name
+ * @return {!angular.JQLite}
+ */
+angular.JQLite.prototype.removeData = function(opt_name) {};
+
+/**
+ * @param {JQLiteSelector} element
+ * @return {!angular.JQLite}
+ */
+angular.JQLite.prototype.replaceWith = function(element) {};
+
+/**
+ * @return {!angular.Scope}
+ */
+angular.JQLite.prototype.scope = function() {};
+
+/**
+ * @param {string=} opt_value
+ * @return {!angular.JQLite|string}
+ */
+angular.JQLite.prototype.text = function(opt_value) {};
+
+/**
+ * @param {string} name
+ * @param {boolean=} opt_condition
+ * @return {!angular.JQLite}
+ */
+angular.JQLite.prototype.toggleClass = function(name, opt_condition) {};
+
+/**
+ * @param {string|!Event} typeOrEvent
+ * @param {*=} opt_value
+ * @return {!angular.JQLite}
+ */
+angular.JQLite.prototype.triggerHandler = function(typeOrEvent, opt_value) {};
+
+/**
+ * @param {string=} opt_type
+ * @param {Function=} opt_fn
+ * @return {!angular.JQLite}
+ */
+angular.JQLite.prototype.unbind = function(opt_type, opt_fn) {};
+
+/**
+ * @param {string=} opt_value
+ * @return {!angular.JQLite|string}
+ */
+angular.JQLite.prototype.val = function(opt_value) {};
+
+/**
+ * @param {JQLiteSelector} element
+ * @return {!angular.JQLite}
+ */
+angular.JQLite.prototype.wrap = function(element) {};
+
+/** @constructor */
+angular.Module = function() {};
+
+/**
+ * @param {string} name
+ * @param {angular.Injectable} animationFactory
+ */
+angular.Module.prototype.animation = function(name, animationFactory) {};
+
+/**
+ * @param {angular.Injectable} configFn
+ * @return {!angular.Module}
+ */
+angular.Module.prototype.config = function(configFn) {};
+
+/**
+ * @param {string} name
+ * @param {*} object
+ * @return {!angular.Module}
+ */
+angular.Module.prototype.constant = function(name, object) {};
+
+/**
+ * Intended to be called with either a name string and a constructor, or an
+ * Object with names as keys and constructors as values.
+ *
+ * @param {string|!Object.<angular.Injectable>} name
+ * @param {angular.Injectable=} opt_constructor
+ * @return {!angular.Module}
+ */
+angular.Module.prototype.controller = function(name, opt_constructor) {};
+
+/**
+ * Intended to be called with either a name string and a directive factory, or
+ * an Object with names as keys and directive factories as values.
+ *
+ * @param {string|!Object.<angular.Injectable>} name
+ * @param {angular.Injectable=} opt_directiveFactory
+ * @return {!angular.Module}
+ */
+angular.Module.prototype.directive = function(name, opt_directiveFactory) {};
+
+/**
+ * @param {string} name
+ * @param {angular.Injectable} providerFunction
+ * @return {!angular.Module}
+ */
+angular.Module.prototype.factory = function(name, providerFunction) {};
+
+/**
+ * @param {string} name
+ * @param {angular.Injectable} filterFactory
+ * @return {!angular.Module}
+ */
+angular.Module.prototype.filter = function(name, filterFactory) {};
+
+/**
+ * @param {string} name
+ * @param {angular.$provide.Provider|angular.Injectable} providerType
+ * @return {!angular.Module}
+ */
+angular.Module.prototype.provider = function(name, providerType) {};
+
+/**
+ * @param {angular.Injectable} initializationFn
+ * @return {!angular.Module}
+ */
+angular.Module.prototype.run = function(initializationFn) {};
+
+/**
+ * @param {string} name
+ * @param {angular.Injectable} constructor
+ * @return {!angular.Module}
+ */
+angular.Module.prototype.service = function(name, constructor) {};
+
+/**
+ * @param {string} name
+ * @param {*} object
+ * @return {!angular.Module}
+ */
+angular.Module.prototype.value = function(name, object) {};
+
+/**
+ * @param {string} name
+ * @param {!angular.Injectable} decorator
+ * @return {!angular.Module}
+ */
+angular.Module.prototype.decorator = function(name, decorator) {};
+
+/**
+ * @type {string}
+ */
+angular.Module.prototype.name = '';
+
+/**
+ * @type {Array.<string>}
+ */
+angular.Module.prototype.requires;
+
+/** @constructor */
+angular.Scope = function() {};
+
+/** @type {string} */
+angular.Scope.prototype.$$phase;
+
+/**
+ * @param {(string|function(!angular.Scope))=} opt_exp
+ * @return {*}
+ */
+angular.Scope.prototype.$apply = function(opt_exp) {};
+
+/**
+ * @param {(string|function(!angular.Scope))=} opt_exp
+ */
+angular.Scope.prototype.$applyAsync = function(opt_exp) {};
+
+/**
+ * @param {string} name
+ * @param {...*} args
+ */
+angular.Scope.prototype.$broadcast = function(name, args) {};
+
+angular.Scope.prototype.$destroy = function() {};
+
+angular.Scope.prototype.$digest = function() {};
+
+/**
+ * @param {string} name
+ * @param {...*} args
+ */
+angular.Scope.prototype.$emit = function(name, args) {};
+
+/**
+ * @param {(string|function(angular.Scope):?)=} opt_exp
+ * @param {Object=} opt_locals
+ * @return {*}
+ */
+angular.Scope.prototype.$eval = function(opt_exp, opt_locals) {};
+
+/**
+ * @param {(string|function())=} opt_exp
+ */
+angular.Scope.prototype.$evalAsync = function(opt_exp) {};
+
+/** @type {string} */
+angular.Scope.prototype.$id;
+
+/**
+ * @param {boolean=} opt_isolate
+ * @return {!angular.Scope}
+ */
+angular.Scope.prototype.$new = function(opt_isolate) {};
+
+/**
+ * @param {string} name
+ * @param {function(!angular.Scope.Event, ...?)} listener
+ * @return {function()}
+ */
+angular.Scope.prototype.$on = function(name, listener) {};
+
+/** @type {!angular.Scope} */
+angular.Scope.prototype.$parent;
+
+/** @type {!angular.Scope} */
+angular.Scope.prototype.$root;
+
+/**
+ * @param {string|!Function} exp
+ * @param {(string|Function)=} opt_listener
+ * @param {boolean=} opt_objectEquality
+ * @return {function()}
+ */
+angular.Scope.prototype.$watch =
+    function(exp, opt_listener, opt_objectEquality) {};
+
+/**
+ * @param {string|!Function} exp
+ * @param {(string|Function)=} opt_listener
+ * @return {function()}
+ */
+angular.Scope.prototype.$watchCollection = function(exp, opt_listener) {};
+
+/**
+ * @param {Array<string|!Function>} exps
+ * @param {(string|Function)=} opt_listener
+ * @return {function()}
+ */
+angular.Scope.prototype.$watchGroup = function(exps, opt_listener) {};
+
+/**
+ * @typedef {{
+ *   currentScope: !angular.Scope,
+ *   defaultPrevented: boolean,
+ *   name: string,
+ *   preventDefault: function(),
+ *   stopPropagation: function(),
+ *   targetScope: !angular.Scope
+ *   }}
+ */
+angular.Scope.Event;
+
+/** @type {!angular.Scope} */
+angular.Scope.Event.currentScope;
+
+/** @type {boolean} */
+angular.Scope.Event.defaultPrevented;
+
+/** @type {string} */
+angular.Scope.Event.name;
+
+angular.Scope.Event.preventDefault = function() {};
+
+angular.Scope.Event.stopPropagation = function() {};
+
+/** @type {!angular.Scope} */
+angular.Scope.Event.targetScope;
+
+/**
+ * @type {Object}
+ */
+angular.version = {};
+
+/**
+ * @type {string}
+ */
+angular.version.full = '';
+
+/**
+ * @type {number}
+ */
+angular.version.major = 0;
+
+/**
+ * @type {number}
+ */
+angular.version.minor = 0;
+
+/**
+ * @type {number}
+ */
+angular.version.dot = 0;
+
+/**
+ * @type {string}
+ */
+angular.version.codeName = '';
+
+/******************************************************************************
+ * $anchorScroll Service
+ *****************************************************************************/
+
+/**
+ * @typedef {function()}
+ */
+angular.$anchorScroll;
+
+/******************************************************************************
+ * $anchorScrollProvider Service
+ *****************************************************************************/
+
+/**
+ * @typedef {{
+ *   disableAutoScrolling: function()
+ *   }}
+ */
+angular.$anchorScrollProvider;
+
+/**
+ * @type {function()}
+ */
+angular.$anchorScrollProvider.disableAutoScrolling = function() {};
+
+/******************************************************************************
+ * $animate Service
+ *****************************************************************************/
+
+/**
+ * @constructor
+ */
+angular.$animate = function() {};
+
+/**
+ * @param {JQLiteSelector} element
+ * @param {Object} from
+ * @param {Object} to
+ * @param {string=} opt_className
+ * @param {Object.<string, *>=} opt_options
+ * @return {!angular.$q.Promise}
+ */
+angular.$animate.prototype.animate = function(
+    element, from, to, opt_className, opt_options) {};
+
+/**
+ * @param {string} event
+ * @param {JQLiteSelector} container
+ * @param {function(JQLiteSelector, string)} callback
+ */
+angular.$animate.prototype.on = function(event, container, callback) {};
+
+/**
+ * @param {string} event
+ * @param {JQLiteSelector=} opt_container
+ * @param {function(JQLiteSelector, string)=} opt_callback
+ */
+angular.$animate.prototype.off = function(event, opt_container, opt_callback) {
+};
+
+/**
+ * @param {JQLiteSelector} element
+ * @param {JQLiteSelector} parentElement
+ */
+angular.$animate.prototype.pin = function(element, parentElement) {};
+
+/**
+ * @param {JQLiteSelector} element
+ * @param {JQLiteSelector} parentElement
+ * @param {JQLiteSelector} afterElement
+ * @param {Object.<string, *>=} opt_options
+ * @return {!angular.$q.Promise}
+ */
+angular.$animate.prototype.enter = function(
+    element, parentElement, afterElement, opt_options) {};
+
+/**
+ * @param {JQLiteSelector} element
+ * @param {Object.<string, *>=} opt_options
+ * @return {!angular.$q.Promise}
+ */
+angular.$animate.prototype.leave = function(element, opt_options) {};
+
+/**
+ * @param {JQLiteSelector} element
+ * @param {JQLiteSelector} parentElement
+ * @param {JQLiteSelector} afterElement
+ * @param {Object.<string, *>=} opt_options
+ * @return {!angular.$q.Promise}
+ */
+angular.$animate.prototype.move = function(
+    element, parentElement, afterElement, opt_options) {};
+
+/**
+ * @param {JQLiteSelector} element
+ * @param {string} className
+ * @param {Object.<string, *>=} opt_options
+ * @return {!angular.$q.Promise}
+ */
+angular.$animate.prototype.addClass = function(
+    element, className, opt_options) {};
+
+/**
+ * @param {JQLiteSelector} element
+ * @param {string} className
+ * @param {Object.<string, *>=} opt_options
+ * @return {!angular.$q.Promise}
+ */
+angular.$animate.prototype.removeClass = function(
+    element, className, opt_options) {};
+
+/**
+ * @param {JQLiteSelector} element
+ * @param {string} add
+ * @param {string} remove
+ * @param {Object.<string, *>=} opt_options
+ * @return {!angular.$q.Promise}
+ */
+angular.$animate.prototype.setClass = function(
+    element, add, remove, opt_options) {};
+
+/**
+ * @param {(boolean|JQLiteSelector)=} opt_elementOrValue
+ * @param {boolean=} opt_value
+ * @return {boolean}
+ */
+angular.$animate.prototype.enabled = function(opt_elementOrValue, opt_value) {};
+
+/**
+ * @param {angular.$q.Promise} animationPromise
+ */
+angular.$animate.prototype.cancel = function(animationPromise) {};
+
+/******************************************************************************
+ * $animateProvider Service
+ *****************************************************************************/
+
+/**
+ * @constructor
+ */
+angular.$animateProvider = function() {};
+
+/**
+ * @param {string} name
+ * @param {Function} factory
+ */
+angular.$animateProvider.prototype.register = function(name, factory) {};
+
+/**
+ * @param {RegExp=} opt_expression
+ */
+angular.$animateProvider.prototype.classNameFilter = function(
+    opt_expression) {};
+
+/******************************************************************************
+ * $ariaProvider Service
+ *****************************************************************************/
+
+/**
+ * @constructor
+ */
+angular.$ariaProvider = function() {};
+
+/**
+ * @param {!{
+ *   ariaHidden: (boolean|undefined),
+ *   ariaChecked: (boolean|undefined),
+ *   ariaDisabled: (boolean|undefined),
+ *   ariaRequired: (boolean|undefined),
+ *   ariaInvalid: (boolean|undefined),
+ *   ariaMultiline: (boolean|undefined),
+ *   ariaValue: (boolean|undefined),
+ *   tabindex: (boolean|undefined),
+ *   bindKeypress: (boolean|undefined),
+ *   bindRoleForClick: (boolean|undefined)
+ * }} config
+ */
+angular.$ariaProvider.prototype.config = function(config) {};
+
+/******************************************************************************
+ * $compile Service
+ *****************************************************************************/
+
+/**
+ * @typedef {
+ *   function(
+ *       (JQLiteSelector|Object),
+ *       function(!angular.Scope, Function=)=, number=):
+ *           function(!angular.Scope,
+ *               function(!angular.JQLite, !angular.Scope=)=,
+ *                   angular.$compile.LinkOptions=): !angular.JQLite}
+ */
+angular.$compile;
+
+/**
+ * @typedef {{
+ *   parentBoundTranscludeFn: (Function|undefined),
+ *   transcludeControllers: (Object|undefined),
+ *   futureParentElement: (angular.JQLite|undefined)
+ * }}
+ */
+angular.$compile.LinkOptions;
+
+// TODO(martinprobst): remaining $compileProvider methods.
+
+/**
+ * @constructor
+ */
+angular.$compileProvider = function() {};
+
+/**
+ * @param {boolean=} opt_enabled
+ * @return {boolean|!angular.$compileProvider}
+ */
+angular.$compileProvider.prototype.debugInfoEnabled = function(opt_enabled) {};
+
+/**
+ * @param {!RegExp=} opt_expression
+ * @return {!RegExp|!angular.$compileProvider}
+ */
+angular.$compileProvider.prototype.aHrefSanitizationWhitelist = function(
+    opt_expression) {};
+
+/**
+ * @param {!RegExp=} opt_expression
+ * @return {!RegExp|!angular.$compileProvider}
+ */
+angular.$compileProvider.prototype.imgSrcSanitizationWhitelist = function(
+    opt_expression) {};
+
+/******************************************************************************
+ * $cacheFactory Service
+ *****************************************************************************/
+
+/**
+ * @typedef {
+ *   function(string, angular.$cacheFactory.Options=):
+ *       !angular.$cacheFactory.Cache}
+ */
+angular.$cacheFactory;
+
+/**
+ * @return {!angular.$cacheFactory.Cache|undefined}
+ */
+angular.$cacheFactory.prototype.get = function() {};
+
+/** @typedef {{capacity: (number|undefined)}} */
+angular.$cacheFactory.Options;
+
+/**
+ * @template T
+ * @constructor
+ */
+angular.$cacheFactory.Cache = function() {};
+
+/**
+ * @return {!angular.$cacheFactory.Cache.Info}
+ */
+angular.$cacheFactory.Cache.prototype.info = function() {};
+
+/**
+ * @param {string} key
+ * @param {T} value
+ */
+angular.$cacheFactory.Cache.prototype.put = function(key, value) {};
+
+/**
+ * @param {string} key
+ * @return {T}
+ */
+angular.$cacheFactory.Cache.prototype.get = function(key) {};
+
+/**
+ * @param {string} key
+ */
+angular.$cacheFactory.Cache.prototype.remove = function(key) {};
+
+angular.$cacheFactory.Cache.prototype.removeAll = function() {};
+angular.$cacheFactory.Cache.prototype.destroy = function() {};
+
+/**
+ * @typedef {{
+ *   id: string,
+ *   size: number,
+ *   options: angular.$cacheFactory.Options
+ *   }}
+ */
+angular.$cacheFactory.Cache.Info;
+
+/******************************************************************************
+ * $controller Service
+ *****************************************************************************/
+
+/**
+ * @typedef {function((Function|string), Object):Object}
+ */
+angular.$controller;
+
+/******************************************************************************
+ * $controllerProvider Service
+ *****************************************************************************/
+
+/**
+ * @typedef {{
+ *   register: function((string|Object), angular.Injectable=),
+ *   allowGlobals: function()
+ *   }}
+ */
+angular.$controllerProvider;
+
+/******************************************************************************
+ * $cookies Service
+ *****************************************************************************/
+
+/**
+ * @constructor
+ */
+angular.$cookies = function() {};
+
+/**
+ * @param {string} key
+ * @return {string|undefined}
+ */
+angular.$cookies.prototype.get = function(key) {};
+
+/**
+ * @param {string} key
+ * @return {?Object|undefined}
+ */
+angular.$cookies.prototype.getObject = function(key) {};
+
+/**
+ * @return {!Object<string, string>}
+ */
+angular.$cookies.prototype.getAll = function() {};
+
+/**
+ * @param {string} key
+ * @param {string} value
+ * @param {!angular.$cookies.Config=} opt_options
+ */
+angular.$cookies.prototype.put = function(key, value, opt_options) {};
+
+/**
+ * @param {string} key
+ * @param {?Object} value
+ * @param {!angular.$cookies.Config=} opt_options
+ */
+angular.$cookies.prototype.putObject = function(key, value, opt_options) {};
+
+/**
+ * @param {string} key
+ * @param {!angular.$cookies.Config=} opt_options
+ */
+angular.$cookies.prototype.remove = function(key, opt_options) {};
+
+/**
+ * See:
+ * https://docs.angularjs.org/api/ngCookies/provider/$cookiesProvider#defaults
+ * @typedef {{
+ *   path: (string|undefined),
+ *   domain: (string|undefined),
+ *   date: (string|!Date|undefined),
+ *   secure: (boolean|undefined)
+ * }}
+ */
+angular.$cookies.Config;
+
+/**
+ * @constructor
+ */
+angular.$cookiesProvider = function() {};
+
+/**
+ * @type {angular.$cookies.Config}
+ */
+angular.$cookiesProvider.prototype.defaults;
+
+/******************************************************************************
+ * $exceptionHandler Service
+ *****************************************************************************/
+
+/**
+ * @typedef {function(Error, string=)}
+ */
+angular.$exceptionHandler;
+
+/******************************************************************************
+ * $filter Service
+ *****************************************************************************/
+
+/**
+ * @typedef {function(string): !Function}
+ */
+angular.$filter;
+
+/**
+ * The 'orderBy' filter is available through $filterProvider and AngularJS
+ * injection; but is not accessed through a documented public API of AngularJS.
+ * <p>In current AngularJS version the injection is satisfied by
+ * angular.orderByFunction, where the implementation is found.
+ * <p>See http://docs.angularjs.org/api/ng.filter:orderBy.
+ * @typedef {function(Array,
+ *     (string|function(?):*|Array.<(string|function(?):*)>),
+ *     boolean=): Array}
+ */
+angular.$filter.orderBy;
+
+/**
+ * @typedef {function(Array,
+ *     (string|Object|function(?):*),
+ *     (function(?):*|boolean)=): Array}
+ */
+angular.$filter.filter;
+
+/******************************************************************************
+ * $filterProvider Service
+ *****************************************************************************/
+
+/**
+ * @typedef {{register: function(string, angular.Injectable)}}
+ */
+angular.$filterProvider;
+
+/**
+ * @param {string} name
+ * @param {angular.Injectable} fn
+ */
+angular.$filterProvider.register = function(name, fn) {};
+
+/******************************************************************************
+ * $http Service
+ *****************************************************************************/
+
+/**
+ * This is a typedef because the closure compiler does not allow
+ * defining a type that is a function with properties.
+ * If you are trying to use the $http service as a function, try
+ * using one of the helper functions instead.
+ * @typedef {{
+ *   delete: function(string, angular.$http.Config=):!angular.$http.HttpPromise,
+ *   get: function(string, angular.$http.Config=):!angular.$http.HttpPromise,
+ *   head: function(string, angular.$http.Config=):!angular.$http.HttpPromise,
+ *   jsonp: function(string, angular.$http.Config=):!angular.$http.HttpPromise,
+ *   patch: function(string, *, angular.$http.Config=):
+ *       !angular.$http.HttpPromise,
+ *   post: function(string, *, angular.$http.Config=):
+ *       !angular.$http.HttpPromise,
+ *   put: function(string, *, angular.$http.Config=):!angular.$http.HttpPromise,
+ *   defaults: angular.$http.Config,
+ *   pendingRequests: !Array.<angular.$http.Config>
+ * }}
+ */
+angular.$http;
+
+/**
+ * @typedef {{
+ *   cache: (boolean|!angular.$cacheFactory.Cache|undefined),
+ *   data: (string|Object|undefined),
+ *   headers: (Object|undefined),
+ *   method: (string|undefined),
+ *   params: (Object.<(string|Object)>|undefined),
+ *   responseType: (string|undefined),
+ *   timeout: (number|!angular.$q.Promise|undefined),
+ *   transformRequest:
+ *       (function((string|Object), Object):(string|Object)|
+ *       Array.<function((string|Object), Object):(string|Object)>|undefined),
+ *   transformResponse:
+ *       (function((string|Object), Object):(string|Object)|
+ *       Array.<function((string|Object), Object):(string|Object)>|undefined),
+ *   url: (string|undefined),
+ *   withCredentials: (boolean|undefined),
+ *   xsrfCookieName: (string|undefined),
+ *   xsrfHeaderName: (string|undefined)
+ * }}
+ */
+angular.$http.Config;
+
+angular.$http.Config.transformRequest;
+
+angular.$http.Config.transformResponse;
+
+// /**
+//  * This extern is currently incomplete as delete is a reserved word.
+//  * To use delete, index $http.
+//  * Example: $http['delete'](url, opt_config);
+//  * @param {string} url
+//  * @param {angular.$http.Config=} opt_config
+//  * @return {!angular.$http.HttpPromise}
+//  */
+// angular.$http.delete = function(url, opt_config) {};
+
+/**
+ * @param {string} url
+ * @param {angular.$http.Config=} opt_config
+ * @return {!angular.$http.HttpPromise}
+ */
+angular.$http.get = function(url, opt_config) {};
+
+/**
+ * @param {string} url
+ * @param {angular.$http.Config=} opt_config
+ * @return {!angular.$http.HttpPromise}
+ */
+angular.$http.head = function(url, opt_config) {};
+
+/**
+ * @param {string} url
+ * @param {angular.$http.Config=} opt_config
+ * @return {!angular.$http.HttpPromise}
+ */
+angular.$http.jsonp = function(url, opt_config) {};
+
+/**
+ * @param {string} url
+ * @param {*} data
+ * @param {angular.$http.Config=} opt_config
+ * @return {!angular.$http.HttpPromise}
+ */
+angular.$http.patch = function(url, data, opt_config) {};
+
+/**
+ * @param {string} url
+ * @param {*} data
+ * @param {angular.$http.Config=} opt_config
+ * @return {!angular.$http.HttpPromise}
+ */
+angular.$http.post = function(url, data, opt_config) {};
+
+/**
+ * @param {string} url
+ * @param {*} data
+ * @param {angular.$http.Config=} opt_config
+ * @return {!angular.$http.HttpPromise}
+ */
+angular.$http.put = function(url, data, opt_config) {};
+
+/**
+ * @type {angular.$http.Config}
+ */
+angular.$http.defaults;
+
+/**
+ * @type {Array.<angular.$http.Config>}
+ * @const
+ */
+angular.$http.pendingRequests;
+
+/**
+ * @typedef {{
+ *   request: (undefined|(function(!angular.$http.Config):
+ *       !angular.$http.Config|!angular.$q.Promise.<!angular.$http.Config>)),
+ *   requestError: (undefined|(function(Object): !angular.$q.Promise|Object)),
+ *   response: (undefined|(function(!angular.$http.Response):
+ *       !angular.$http.Response|!angular.$q.Promise.<!angular.$http.Response>)),
+ *   responseError: (undefined|(function(Object): !angular.$q.Promise|Object))
+ *   }}
+ */
+angular.$http.Interceptor;
+
+/**
+ * @constructor
+ */
+angular.$HttpProvider = function() {};
+
+/**
+ * @type {angular.$http.Config}
+ */
+angular.$HttpProvider.prototype.defaults;
+
+/**
+ * @type {!Array.<string|function(...?): !angular.$http.Interceptor>}
+ */
+angular.$HttpProvider.prototype.interceptors;
+
+/**
+ * @param {boolean=} opt_value
+ * @return {boolean|!angular.$HttpProvider}
+ */
+angular.$HttpProvider.prototype.useApplyAsync = function(opt_value) {};
+
+/**
+ * @param {boolean=} opt_value
+ * @return {boolean|!angular.$HttpProvider}
+ */
+angular.$HttpProvider.prototype.useLegacyPromiseExtensions = function(
+    opt_value) {};
+
+/******************************************************************************
+ * $injector Service
+ *****************************************************************************/
+
+/**
+ * @constructor
+ */
+angular.$injector = function() {};
+
+/**
+ * @param {angular.Injectable} fn
+ * @return {Array.<string>}
+ */
+angular.$injector.prototype.annotate = function(fn) {};
+
+/**
+ * @param {string} name
+ * @return {?}
+ */
+angular.$injector.prototype.get = function(name) {};
+
+/**
+ * @param {string} name
+ * @return {boolean}
+ */
+angular.$injector.prototype.has = function(name) {};
+
+/**
+ * @param {!Function} type
+ * @param {Object=} opt_locals
+ * @return {Object}
+ */
+angular.$injector.prototype.instantiate = function(type, opt_locals) {};
+
+/**
+ * @param {angular.Injectable} fn
+ * @param {Object=} opt_self
+ * @param {Object=} opt_locals
+ * @return {?}
+ */
+angular.$injector.prototype.invoke = function(fn, opt_self, opt_locals) {};
+
+/******************************************************************************
+ * $interpolateProvider Service
+ *****************************************************************************/
+
+/**
+ * @constructor
+ */
+angular.$interpolateProvider = function() {};
+
+/** @type {function(string)} */
+angular.$interpolateProvider.prototype.startSymbol;
+
+/** @type {function(string)} */
+angular.$interpolateProvider.prototype.endSymbol;
+
+/******************************************************************************
+ * $interpolate Service
+ *****************************************************************************/
+
+/**
+ * @typedef {function(string, boolean=, string=, boolean=):?function(Object):*}
+ */
+angular.$interpolate;
+
+/******************************************************************************
+ * $interval Service
+ *****************************************************************************/
+
+/**
+ * @typedef {
+ *  function(function(), number=, number=, boolean=):!angular.$q.Promise
+ * }
+ */
+angular.$interval;
+
+/**
+ * Augment the angular.$interval type definition by reopening the type via an
+ * artificial angular.$interval instance.
+ *
+ * This allows us to define methods on function objects which is something
+ * that can't be expressed via typical type annotations.
+ *
+ * @type {angular.$interval}
+ */
+angular.$interval_;
+
+/**
+ * @type {function(!angular.$q.Promise):boolean}
+ */
+angular.$interval_.cancel = function(promise) {};
+
+/******************************************************************************
+ * $location Service
+ *****************************************************************************/
+
+/**
+ * @constructor
+ */
+angular.$location = function() {};
+
+/**
+ * @return {string}
+ */
+angular.$location.prototype.absUrl = function() {};
+
+/**
+ * @param {string=} opt_hash
+ * @return {string}
+ */
+angular.$location.prototype.hash = function(opt_hash) {};
+
+/**
+ * @return {string}
+ */
+angular.$location.prototype.host = function() {};
+
+/**
+ * @param {string=} opt_path
+ * @return {string|!angular.$location}
+ */
+angular.$location.prototype.path = function(opt_path) {};
+
+/**
+ * @return {number}
+ */
+angular.$location.prototype.port = function() {};
+
+/**
+ * @return {string}
+ */
+angular.$location.prototype.protocol = function() {};
+
+/**
+ * @type {function()}
+ */
+angular.$location.prototype.replace = function() {};
+
+/**
+ * @param {(string|Object.<string, string>)=} opt_search
+ * @param {?(string|Array.<string>|boolean|number)=} opt_paramValue
+ * @return {(!Object|!angular.$location)}
+ */
+angular.$location.prototype.search = function(opt_search, opt_paramValue) {};
+
+/**
+ * @param {string=} opt_url
+ * @return {string}
+ */
+angular.$location.prototype.url = function(opt_url) {};
+
+/******************************************************************************
+ * $locationProvider Service
+ *****************************************************************************/
+
+/**
+ * @typedef {{
+ *   enabled: (boolean|undefined),
+ *   requireBase: (boolean|undefined)
+ * }}
+ */
+angular.$locationProvider.html5ModeConfig;
+
+/**
+ * @constructor
+ */
+angular.$locationProvider = function() {};
+
+/**
+ * @param {string=} opt_prefix
+ * @return {string|!angular.$locationProvider}
+ */
+angular.$locationProvider.prototype.hashPrefix = function(opt_prefix) {};
+
+/**
+ * @param {(boolean|angular.$locationProvider.html5ModeConfig)=} opt_mode
+ * @return {boolean|!angular.$locationProvider}
+ */
+angular.$locationProvider.prototype.html5Mode = function(opt_mode) {};
+
+/******************************************************************************
+ * $logProvider Service
+ *****************************************************************************/
+
+/** @constructor */
+angular.$logProvider = function() {};
+
+/**
+ * @param {boolean=} opt_debugEnabled
+ * @return {*}
+ */
+angular.$logProvider.prototype.debugEnabled = function(opt_debugEnabled) {};
+
+/******************************************************************************
+ * $log Service
+ *****************************************************************************/
+
+/**
+ * @constructor
+ */
+angular.$log = function() {};
+
+/**
+ * @param {...*} var_args
+ */
+angular.$log.prototype.debug = function(var_args) {};
+
+/**
+ * @param {...*} var_args
+ */
+angular.$log.prototype.error = function(var_args) {};
+
+/**
+ * @param {...*} var_args
+ */
+angular.$log.prototype.info = function(var_args) {};
+
+/**
+ * @param {...*} var_args
+ */
+angular.$log.prototype.log = function(var_args) {};
+
+/**
+ * @param {...*} var_args
+ */
+angular.$log.prototype.warn = function(var_args) {};
+
+/******************************************************************************
+ * NgModelController
+ *****************************************************************************/
+
+/**
+ * @constructor
+ */
+angular.NgModelController = function() {};
+
+/**
+ * @type {?}
+ */
+angular.NgModelController.prototype.$modelValue;
+
+/**
+ * @type {boolean}
+ */
+angular.NgModelController.prototype.$dirty;
+
+/**
+ * @type {!Object.<boolean>}
+ */
+angular.NgModelController.prototype.$error;
+
+/**
+ * @type {!Array.<function(?):*>}
+ */
+angular.NgModelController.prototype.$formatters;
+
+/**
+ * @type {boolean}
+ */
+angular.NgModelController.prototype.$invalid;
+
+/**
+ * @type {!Array.<function(?):*>}
+ */
+angular.NgModelController.prototype.$parsers;
+
+/**
+ * @type {boolean}
+ */
+angular.NgModelController.prototype.$pristine;
+
+angular.NgModelController.prototype.$render = function() {};
+
+/**
+ * @param {string} key
+ * @param {boolean} isValid
+ */
+angular.NgModelController.prototype.$setValidity = function(key, isValid) {};
+
+/**
+ * @param {?} value
+ */
+angular.NgModelController.prototype.$setViewValue = function(value) {};
+
+/**
+ * @type {boolean}
+ */
+angular.NgModelController.prototype.$valid;
+
+/**
+ * @type {!Array.<function()>}
+ */
+angular.NgModelController.prototype.$viewChangeListeners;
+
+/**
+ * @type {?}
+ */
+angular.NgModelController.prototype.$viewValue;
+
+/**
+ * @type {!Object.<string, function(?, ?):*>}
+ */
+angular.NgModelController.prototype.$validators;
+
+/**
+ * @type {Object.<string, function(?, ?):*>}
+ */
+angular.NgModelController.prototype.$asyncValidators;
+
+/**
+ * @type {boolean}
+ */
+angular.NgModelController.prototype.$untouched;
+
+/**
+ * @type {boolean}
+ */
+angular.NgModelController.prototype.$touched;
+
+/**
+ * @param {?} value
+ */
+angular.NgModelController.prototype.$isEmpty = function(value) {};
+
+/**
+ * @type {function()}
+ */
+angular.NgModelController.prototype.$setPristine = function() {};
+
+/**
+ * @type {function()}
+ */
+angular.NgModelController.prototype.$setDirty = function() {};
+
+/**
+ * @type {function()}
+ */
+angular.NgModelController.prototype.$setUntouched = function() {};
+
+/**
+ * @type {function()}
+ */
+angular.NgModelController.prototype.$setTouched = function() {};
+
+/**
+ * @type {function()}
+ */
+angular.NgModelController.prototype.$rollbackViewValue = function() {};
+
+/**
+ * @type {function()}
+ */
+angular.NgModelController.prototype.$validate = function() {};
+
+/**
+ * @type {function()}
+ */
+angular.NgModelController.prototype.$commitViewValue = function() {};
+
+/******************************************************************************
+ * FormController
+ *****************************************************************************/
+
+/**
+ * @constructor
+ */
+angular.FormController = function() {};
+
+/**
+ * @param {*} control
+ */
+angular.FormController.prototype.$addControl = function(control) {};
+
+/**
+ * @type {function()}
+ */
+angular.FormController.prototype.$rollbackViewValue = function() {};
+
+/**
+ * @type {function()}
+ */
+angular.FormController.prototype.$commitViewValue = function() {};
+
+/**
+ * @type {boolean}
+ */
+angular.FormController.prototype.$dirty;
+
+/**
+ * @type {!Object.<boolean|!Array.<*>>}
+ */
+angular.FormController.prototype.$error;
+
+/**
+ * @type {boolean}
+ */
+angular.FormController.prototype.$invalid;
+
+/**
+ * @type {string}
+ */
+angular.FormController.prototype.$name;
+
+/**
+ * @type {boolean}
+ */
+angular.FormController.prototype.$pristine;
+
+/**
+ * @param {*} control
+ */
+angular.FormController.prototype.$removeControl = function(control) {};
+
+/**
+ * @type {function()}
+ */
+angular.FormController.prototype.$setDirty = function() {};
+
+/**
+ * @type {function()}
+ */
+angular.FormController.prototype.$setPristine = function() {};
+
+/**
+ * @type {function()}
+ */
+angular.FormController.prototype.$setUntouched = function() {};
+
+/**
+ * @type {function()}
+ */
+angular.FormController.prototype.$setSubmitted = function() {};
+
+/**
+ * @type {boolean}
+ */
+angular.FormController.prototype.$submitted;
+
+/**
+ * @param {string} validationToken
+ * @param {boolean} isValid
+ * @param {*} control
+ */
+angular.FormController.prototype.$setValidity = function(
+    validationToken, isValid, control) {};
+
+/**
+ * @type {boolean}
+ */
+angular.FormController.prototype.$valid;
+
+/******************************************************************************
+ * $parse Service
+ *****************************************************************************/
+
+/**
+ * @typedef {function(string):!angular.$parse.Expression}
+ */
+angular.$parse;
+
+/**
+ * @typedef {function((!angular.Scope|!Object), Object=):*}
+ */
+angular.$parse.Expression;
+
+/**
+ * Augment the angular.$parse.Expression type definition by reopening the type
+ * via an artificial angular.$parse instance.
+ *
+ * This allows us to define methods on function objects which is something
+ * that can't be expressed via typical type annotations.
+ *
+ * @type {angular.$parse.Expression}
+ */
+angular.$parse_;
+
+/**
+ * @type {function((!angular.Scope|!Object), *)}
+ */
+angular.$parse_.assign = function(scope, newValue) {};
+
+/******************************************************************************
+ * $provide Service
+ *****************************************************************************/
+
+/**
+ * @constructor
+ */
+angular.$provide = function() {};
+
+/** @typedef {{$get: (!Array.<string|!Function>|!Function)}} */
+angular.$provide.Provider;
+
+/** @typedef {(!Array.<string|!Function>|!Function)} */
+angular.$provide.Provider.$get;
+
+/**
+ * @param {string} name
+ * @param {*} object
+ * @return {Object}
+ */
+angular.$provide.prototype.constant = function(name, object) {};
+
+/**
+ * @param {string} name
+ * @param {!angular.Injectable} decorator
+ */
+angular.$provide.prototype.decorator = function(name, decorator) {};
+
+/**
+ * @param {string} name
+ * @param {angular.Injectable} providerFunction
+ * @return {Object}
+ */
+angular.$provide.prototype.factory = function(name, providerFunction) {};
+
+/**
+ * @param {string} name
+ * @param {angular.Injectable|angular.$provide.Provider}
+ *     providerType
+ * @return {Object}
+ */
+angular.$provide.prototype.provider = function(name, providerType) {};
+
+/**
+ * @param {string} name
+ * @param {angular.Injectable} constructor
+ * @return {Object}
+ */
+angular.$provide.prototype.service = function(name, constructor) {};
+
+/**
+ * @param {string} name
+ * @param {*} object
+ * @return {Object}
+ */
+angular.$provide.prototype.value = function(name, object) {};
+
+/******************************************************************************
+ * $route Service
+ *****************************************************************************/
+
+/** @constructor */
+angular.$route = function() {};
+
+/** @type {function()} */
+angular.$route.prototype.reload = function() {};
+
+/**
+ * @param {!Object<string,string>} object
+ */
+angular.$route.prototype.updateParams = function(object) {};
+
+/** @type {!angular.$route.Route} */
+angular.$route.prototype.current;
+
+/** @type {Array.<!angular.$route.Route>} */
+angular.$route.prototype.routes;
+
+/** @constructor */
+angular.$route.Route = function() {};
+
+/** @type {angular.$routeProvider.Params} */
+angular.$route.Route.prototype.$route;
+
+/** @type {Object.<string, *>} */
+angular.$route.Route.prototype.locals;
+
+/** @type {Object.<string, string>} */
+angular.$route.Route.prototype.params;
+
+/** @type {Object.<string, string>} */
+angular.$route.Route.prototype.pathParams;
+
+/** @type {Object.<string, *>} */
+angular.$route.Route.prototype.scope;
+
+/** @type {string|undefined} */
+angular.$route.Route.prototype.originalPath;
+
+/** @type {RegExp|undefined} */
+angular.$route.Route.prototype.regexp;
+
+/******************************************************************************
+ * $routeParams Service
+ *****************************************************************************/
+
+// TODO: This should be !Object.<string|boolean> because valueless query params
+// (without even an equal sign) come through as boolean "true".
+
+/** @typedef {!Object.<string>} */
+angular.$routeParams;
+
+/******************************************************************************
+ * $routeProvider Service
+ *****************************************************************************/
+
+/** @constructor */
+angular.$routeProvider = function() {};
+
+/**
+ * @param {(string|!angular.$routeProvider.Params)} params
+ * @return {!angular.$routeProvider}
+ */
+angular.$routeProvider.prototype.otherwise = function(params) {};
+
+/**
+ * @param {string} path
+ * @param {angular.$routeProvider.Params} route
+ * @return {!angular.$routeProvider}
+ */
+angular.$routeProvider.prototype.when = function(path, route) {};
+
+/**
+ * @typedef {{
+ *   controller: (angular.Injectable|string|undefined),
+ *   controllerAs: (string|undefined),
+ *   template: (string|undefined),
+ *   templateUrl: (string|function(!Object.<string,string>=)|undefined),
+ *   resolve: (Object.<string, (
+ *       string|angular.Injectable|!angular.$q.Promise
+ *       )>|undefined),
+ *   redirectTo: (
+ *       string|function(Object.<string>, string, Object): string|undefined),
+ *   reloadOnSearch: (boolean|undefined)
+ *   }}
+ */
+angular.$routeProvider.Params;
+
+/** @type {angular.Injectable|string} */
+angular.$routeProvider.Params.controller;
+
+/** @type {string} */
+angular.$routeProvider.Params.controllerAs;
+
+/** @type {string} */
+angular.$routeProvider.Params.template;
+
+/** @type {string|function(!Object.<string,string>=)} */
+angular.$routeProvider.Params.templateUrl;
+
+/** @type {Object.<string, (string|angular.Injectable|!angular.$q.Promise)>} */
+angular.$routeProvider.Params.resolve;
+
+/** @type {string|function(Object.<string>, string, Object): string} */
+angular.$routeProvider.Params.redirectTo;
+
+/** @type {boolean} */
+angular.$routeProvider.Params.reloadOnSearch;
+
+/******************************************************************************
+ * $sanitize Service
+ *****************************************************************************/
+
+/** @typedef {function(string):string} */
+angular.$sanitize;
+
+/******************************************************************************
+ * $sce Service
+ *****************************************************************************/
+
+/**
+ * Ref: http://docs.angularjs.org/api/ng.$sce
+ *
+ * @typedef {{
+ *   HTML: string,
+ *   CSS: string,
+ *   URL: string,
+ *   JS: string,
+ *   RESOURCE_URL: string,
+ *   isEnabled: function(): boolean,
+ *   parseAs: function(string, string): !angular.$parse.Expression,
+ *   getTrusted: function(string, *): string,
+ *   trustAs: function(string, string): *,
+ *   parseAsHtml: function(string): !angular.$parse.Expression,
+ *   parseAsCss: function(string): !angular.$parse.Expression,
+ *   parseAsUrl: function(string): !angular.$parse.Expression,
+ *   parseAsJs: function(string): !angular.$parse.Expression,
+ *   parseAsResourceUrl: function(string): !angular.$parse.Expression,
+ *   getTrustedHtml: function(*): string,
+ *   getTrustedCss: function(*): string,
+ *   getTrustedUrl: function(*): string,
+ *   getTrustedJs: function(*): string,
+ *   getTrustedResourceUrl: function(*): string,
+ *   trustAsHtml: function(string): *,
+ *   trustAsCss: function(string): *,
+ *   trustAsUrl: function(string): *,
+ *   trustAsJs: function(string): *,
+ *   trustAsResourceUrl: function(string): *
+ *   }}
+ *****************************************************************************/
+angular.$sce;
+
+
+/** @const {string} */
+angular.$sce.HTML;
+
+/** @const {string} */
+angular.$sce.CSS;
+
+/** @const {string} */
+angular.$sce.URL;
+
+/** @const {string} */
+angular.$sce.JS;
+
+/** @const {string} */
+angular.$sce.RESOURCE_URL;
+
+/** @return {boolean} */
+angular.$sce.isEnabled = function() {};
+
+/**
+ * @param {string} type
+ * @param {string} expression
+ * @return {!angular.$parse.Expression}
+ */
+angular.$sce.parseAs = function(type, expression) {};
+
+/**
+ * @param {string} type
+ * @param {*} maybeTrusted
+ * @return {string}
+ */
+angular.$sce.getTrusted = function(type, maybeTrusted) {};
+
+/**
+ * @param {string} type
+ * @param {string} trustedValue
+ * @return {*}
+ */
+angular.$sce.trustAs = function(type, trustedValue) {};
+
+/**
+ * @param {string} expression
+ * @return {!angular.$parse.Expression}
+ */
+angular.$sce.parseAsHtml = function(expression) {};
+
+/**
+ * @param {string} expression
+ * @return {!angular.$parse.Expression}
+ */
+angular.$sce.parseAsCss = function(expression) {};
+
+/**
+ * @param {string} expression
+ * @return {!angular.$parse.Expression}
+ */
+angular.$sce.parseAsUrl = function(expression) {};
+
+/**
+ * @param {string} expression
+ * @return {!angular.$parse.Expression}
+ */
+angular.$sce.parseAsJs = function(expression) {};
+
+/**
+ * @param {string} expression
+ * @return {!angular.$parse.Expression}
+ */
+angular.$sce.parseAsResourceUrl = function(expression) {};
+
+/**
+ * @param {*} maybeTrusted
+ * @return {string}
+ */
+angular.$sce.getTrustedHtml = function(maybeTrusted) {};
+
+/**
+ * @param {*} maybeTrusted
+ * @return {string}
+ */
+angular.$sce.getTrustedCss = function(maybeTrusted) {};
+
+/**
+ * @param {*} maybeTrusted
+ * @return {string}
+ */
+angular.$sce.getTrustedUrl = function(maybeTrusted) {};
+
+/**
+ * @param {*} maybeTrusted
+ * @return {string}
+ */
+angular.$sce.getTrustedJs = function(maybeTrusted) {};
+
+/**
+ * @param {*} maybeTrusted
+ * @return {string}
+ */
+angular.$sce.getTrustedResourceUrl = function(maybeTrusted) {};
+
+/**
+ * @param {string} trustedValue
+ * @return {*}
+ */
+angular.$sce.trustAsHtml = function(trustedValue) {};
+
+/**
+ * @param {string} trustedValue
+ * @return {*}
+ */
+angular.$sce.trustAsCss = function(trustedValue) {};
+
+/**
+ * @param {string} trustedValue
+ * @return {*}
+ */
+angular.$sce.trustAsUrl = function(trustedValue) {};
+
+/**
+ * @param {string} trustedValue
+ * @return {*}
+ */
+angular.$sce.trustAsJs = function(trustedValue) {};
+
+/**
+ * @param {string} trustedValue
+ * @return {*}
+ */
+angular.$sce.trustAsResourceUrl = function(trustedValue) {};
+
+/******************************************************************************
+ * $sceDelegate Service
+ *****************************************************************************/
+
+/**
+ * Ref: http://docs.angularjs.org/api/ng/service/$sceDelegate
+ *
+ * @constructor
+ */
+angular.$sceDelegate = function() {};
+
+/**
+ * @param {string} type
+ * @param {*} value
+ * @return {*}
+ */
+angular.$sceDelegate.prototype.trustAs = function(type, value) {};
+
+/**
+ * Note: because this method overrides Object.prototype.valueOf, the value
+ * parameter needs to be annotated as optional to keep the compiler happy (as
+ * otherwise the signature won't match Object.prototype.valueOf).
+ *
+ * @override
+ * @param {*=} value
+ * @return {*}
+ */
+angular.$sceDelegate.prototype.valueOf = function(value) {};
+
+/**
+ * @param {string} type
+ * @param {*} maybeTrusted
+ * @return {*}
+ */
+angular.$sceDelegate.prototype.getTrusted = function(type, maybeTrusted) {};
+
+/******************************************************************************
+ * $sceDelegateProvider Service
+ *****************************************************************************/
+
+/**
+ * Ref: http://docs.angularjs.org/api/ng/provider/$sceDelegateProvider
+ *
+ * @constructor
+ */
+angular.$sceDelegateProvider = function() {};
+
+/**
+ * @param {Array.<string>=} opt_whitelist
+ * @return {!Array.<string>}
+ */
+angular.$sceDelegateProvider.prototype.resourceUrlWhitelist = function(
+    opt_whitelist) {};
+
+/**
+ * @param {Array.<string>=} opt_blacklist
+ * @return {!Array.<string>}
+ */
+angular.$sceDelegateProvider.prototype.resourceUrlBlacklist = function(
+    opt_blacklist) {};
+
+/******************************************************************************
+ * $templateCache Service
+ *****************************************************************************/
+
+/**
+ * @typedef {!angular.$cacheFactory.Cache.<string>}
+ */
+angular.$templateCache;
+
+/******************************************************************************
+ * $timeout Service
+ *****************************************************************************/
+
+/**
+ * @typedef {function(Function=, number=, boolean=, ...*):!angular.$q.Promise}
+ */
+angular.$timeout;
+
+/**
+ * Augment the angular.$timeout type definition by reopening the type via an
+ * artificial angular.$timeout instance.
+ *
+ * This allows us to define methods on function objects which is something
+ * that can't be expressed via typical type annotations.
+ *
+ * @type {angular.$timeout}
+ */
+angular.$timeout_;
+
+/**
+ * @type {function(angular.$q.Promise=):boolean}
+ */
+angular.$timeout_.cancel = function(promise) {};
+
+/******************************************************************************
+ * $window Service
+ *****************************************************************************/
+
+/** @typedef {!Window} */
+angular.$window;

--- a/client/externs/angular_ui_router.js
+++ b/client/externs/angular_ui_router.js
@@ -1,0 +1,230 @@
+/*
+ * Copyright 2014 The Closure Compiler Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Externs for ui-router.
+ *
+ * API Reference: http://angular-ui.github.io/ui-router/site/#/api/ui.router
+ *
+ * @externs
+ */
+
+
+/**
+ * Suppresses the compiler warning when multiple externs files declare the
+ * ui namespace.
+ * @suppress {duplicate}
+ * @noalias
+ */
+var ui = {};
+
+
+/**
+ * @type {Object}
+ * @const
+ */
+ui.router = {};
+
+
+/**
+ * @typedef {{
+ *   params: Object,
+ *   current: Object,
+ *   transition: ?angular.$q.Promise,
+ *   get: function(...),
+ *   go: function(...),
+ *   href: function(...),
+ *   includes: function(...),
+ *   is: function(...),
+ *   reload: function(...),
+ *   transitionTo: function(...)
+ * }}
+ */
+ui.router.$state;
+
+
+/**
+ * @type {ui.router.State}
+ */
+ui.router.$state.current;
+
+
+/**
+ * @type {Object}
+ */
+ui.router.$state.params;
+
+
+/**
+ * @type {?angular.$q.Promise}
+ */
+ui.router.$state.transition;
+
+
+/**
+ * @param {?string|Object=} stateOrName
+ * @param {?string|Object=} context
+ * @return {Object|Array}
+ */
+ui.router.$state.get = function(stateOrName, context) {};
+
+/**
+ * @typedef {{
+ *   location: (boolean|string|undefined),
+ *   inherit: (boolean|undefined),
+ *   relative: (Object|undefined),
+ *   notify: (boolean|undefined),
+ *   reload: (boolean|undefined)
+ * }}
+ */
+ui.router.$state.GoOptions_;
+
+/**
+ * @param {string} to
+ * @param {Object=} params
+ * @param {(ui.router.$state.GoOptions_|Object)=} options
+ * @return {angular.$q.Promise}
+ */
+ui.router.$state.go = function(to, params, options) {};
+
+
+/**
+ * @param {?string|Object} stateOrName
+ * @param {Object=} params
+ * @param {Object=} options
+ * @return {string} compiled state url
+ */
+ui.router.$state.href = function(stateOrName, params, options) {};
+
+
+/**
+ * @param {?string} stateOrName
+ * @param {Object=} params
+ * @param {Object=} options
+ */
+ui.router.$state.includes = function(stateOrName, params, options) {};
+
+
+/**
+ * @param {?string|Object} stateOrName
+ * @param {Object=} params
+ * @param {Object=} options
+ * @return {boolean}
+ */
+ui.router.$state.is = function(stateOrName, params, options) {};
+
+
+/**
+ * @return {angular.$q.Promise}
+ */
+ui.router.$state.reload = function() {};
+
+
+/**
+ * @param {string} to
+ * @param {Object=} toParams
+ * @param {Object=} options
+ */
+ui.router.$state.transitionTo = function(to, toParams, options) {};
+
+
+/**
+ * @typedef {Object.<string, string>}
+ */
+ui.router.$stateParams;
+
+
+/**
+ * This is the object that the ui-router passes to callback functions listening
+ * on ui router events such as {@code $stateChangeStart} or
+ * {@code $stateChangeError} as the {@code toState} and {@code fromState}.
+ * Example:
+ * $rootScope.$on('$stateChangeStart', function(
+ *     event, toState, toParams, fromState, fromParams){ ... });
+ *
+ * @typedef {{
+ *     'abstract': (boolean|undefined),
+ *     controller: (string|Function|undefined),
+ *     controllerAs: (string|undefined),
+ *     controllerProvider: (Function|undefined),
+ *     data: (Object|undefined),
+ *     name: string,
+ *     onEnter: (Object|undefined),
+ *     onExit: (Object|undefined),
+ *     params: (Object|undefined),
+ *     reloadOnSearch: (boolean|undefined),
+ *     resolve: (Object.<string, !Function>|undefined),
+ *     template: (string|Function|undefined),
+ *     templateUrl: (string|Function|undefined),
+ *     templateProvider: (Function|undefined),
+ *     url: (string|undefined),
+ *     views: (Object|undefined)
+ * }}
+ */
+ui.router.State;
+
+
+
+/**
+ * @constructor
+ */
+ui.router.$urlMatcherFactory = function() {};
+
+
+
+/**
+ * @constructor
+ * @param {!ui.router.$urlMatcherFactory} $urlMatcherFactory
+ */
+ui.router.$urlRouterProvider = function($urlMatcherFactory) {};
+
+
+/**
+ * @param {string|RegExp} url
+ * @param {string|function(...)|Array.<!Object>} route
+ */
+ui.router.$urlRouterProvider.prototype.when = function(url, route) {};
+
+
+/**
+ * @param {string|function(...)} path
+ */
+ui.router.$urlRouterProvider.prototype.otherwise = function(path) {};
+
+
+/**
+ * @param {function(...)} rule
+ */
+ui.router.$urlRouterProvider.prototype.rule = function(rule) {};
+
+
+
+/**
+ * @constructor
+ * @param {!ui.router.$urlRouterProvider} $urlRouterProvider
+ * @param {!ui.router.$urlMatcherFactory} $urlMatcherFactory
+ * @param {!angular.$locationProvider} $locationProvider
+ */
+ui.router.$stateProvider = function(
+    $urlRouterProvider, $urlMatcherFactory, $locationProvider) {};
+
+
+/**
+ * @param {!string} name
+ * @param {Object} definition
+ * @return {!ui.router.$stateProvider}
+ */
+ui.router.$stateProvider.prototype.state = function(name, definition) {};

--- a/client/externs/gviz-api.js
+++ b/client/externs/gviz-api.js
@@ -1,0 +1,460 @@
+// Copyright 2009 Google Inc.
+// All Rights Reserved.
+
+/**
+ * This file exposes the external Google Visualization API.
+ *
+ * The file can be used to enable auto complete of objects and methods provided by the
+ * Google Visualization API, and for easier exploration of the API.
+ *
+ * To enable auto complete in a development environment - copy the file into the project
+ * you are working on where the development tool you are using can index the file.
+ *
+ * Disclaimer: there may be missing classes and methods and the file may
+ * be updated and/or changed. For the most up to date API reference please visit:
+ * {@link http://code.google.com/intl/iw/apis/visualization/documentation/reference.html}
+ */
+
+var google = {};
+google.visualization = {};
+
+/** @constructor */
+google.visualization.DataTable = function(opt_data, opt_version) {};
+google.visualization.DataTable.prototype.getNumberOfRows = function() {};
+google.visualization.DataTable.prototype.getNumberOfColumns = function() {};
+google.visualization.DataTable.prototype.clone = function() {};
+google.visualization.DataTable.prototype.getColumnId = function(columnIndex) {};
+google.visualization.DataTable.prototype.getColumnIndex = function(columnId) {};
+google.visualization.DataTable.prototype.getColumnLabel = function(columnIndex) {};
+google.visualization.DataTable.prototype.getColumnPattern = function(columnIndex) {};
+google.visualization.DataTable.prototype.getColumnRole = function(columnIndex) {};
+google.visualization.DataTable.prototype.getColumnType = function(columnIndex) {};
+google.visualization.DataTable.prototype.getValue = function(rowIndex, columnIndex) {};
+google.visualization.DataTable.prototype.getFormattedValue = function(rowIndex, columnIndex) {};
+google.visualization.DataTable.prototype.getProperty = function(rowIndex, columnIndex, property) {};
+google.visualization.DataTable.prototype.getProperties = function(rowIndex, columnIndex) {};
+google.visualization.DataTable.prototype.getTableProperties = function() {};
+google.visualization.DataTable.prototype.getTableProperty = function(property) {};
+google.visualization.DataTable.prototype.setTableProperties = function(properties) {};
+google.visualization.DataTable.prototype.setTableProperty = function(property, value) {};
+google.visualization.DataTable.prototype.setValue = function(rowIndex, columnIndex, value) {};
+google.visualization.DataTable.prototype.setFormattedValue = function(rowIndex, columnIndex, formattedValue) {};
+google.visualization.DataTable.prototype.setProperties = function(rowIndex, columnIndex, properties) {};
+google.visualization.DataTable.prototype.setProperty = function(rowIndex, columnIndex, property, value) {};
+google.visualization.DataTable.prototype.setCell = function(rowIndex, columnIndex, opt_value, opt_formattedValue, opt_properties) {};
+google.visualization.DataTable.prototype.setRowProperties = function(rowIndex, properties) {};
+google.visualization.DataTable.prototype.setRowProperty = function(rowIndex, property, value) {};
+google.visualization.DataTable.prototype.getRowProperty = function(rowIndex, property) {};
+google.visualization.DataTable.prototype.getRowProperties = function(rowIndex) {};
+google.visualization.DataTable.prototype.setColumnLabel = function(columnIndex, newLabel) {};
+google.visualization.DataTable.prototype.setColumnProperties = function(columnIndex, properties) {};
+google.visualization.DataTable.prototype.setColumnProperty = function(columnIndex, property, value) {};
+google.visualization.DataTable.prototype.getColumnProperty = function(columnIndex, property) {};
+google.visualization.DataTable.prototype.getColumnProperties = function(columnIndex) {};
+google.visualization.DataTable.prototype.insertColumn = function(atColIndex, type, opt_label, opt_id) {};
+google.visualization.DataTable.prototype.addColumn = function(type, opt_label, opt_id) {};
+google.visualization.DataTable.prototype.insertRows = function(atRowIndex, numOrArray) {};
+google.visualization.DataTable.prototype.addRows = function(numOrArray) {};
+google.visualization.DataTable.prototype.addRow = function(opt_cellArray) {};
+google.visualization.DataTable.prototype.getColumnRange = function(columnIndex) {};
+google.visualization.DataTable.prototype.getSortedRows = function(sortColumns) {};
+google.visualization.DataTable.prototype.sort = function(sortColumns) {};
+google.visualization.DataTable.prototype.getDistinctValues = function(column) {};
+google.visualization.DataTable.prototype.getFilteredRows = function(columnFilters) {};
+google.visualization.DataTable.prototype.removeRows = function(fromRowIndex, numRows) {};
+google.visualization.DataTable.prototype.removeRow = function(rowIndex) {};
+google.visualization.DataTable.prototype.removeColumns = function(fromColIndex, numCols) {};
+google.visualization.DataTable.prototype.removeColumn = function(colIndex) {};
+
+/** @return {string} JSON representation. */
+google.visualization.DataTable.prototype.toJSON = function() {};
+
+/** @constructor */
+google.visualization.QueryResponse = function(responseObj) {};
+google.visualization.QueryResponse.getVersionFromResponse = function(responseObj) {};
+google.visualization.QueryResponse.prototype.getVersion = function() {};
+google.visualization.QueryResponse.prototype.getExecutionStatus = function() {};
+google.visualization.QueryResponse.prototype.isError = function() {};
+google.visualization.QueryResponse.prototype.hasWarning = function() {};
+google.visualization.QueryResponse.prototype.containsReason = function(reason) {};
+google.visualization.QueryResponse.prototype.getDataSignature = function() {};
+google.visualization.QueryResponse.prototype.getDataTable = function() {};
+google.visualization.QueryResponse.prototype.getReasons = function() {};
+google.visualization.QueryResponse.prototype.getMessage = function() {};
+google.visualization.QueryResponse.prototype.getDetailedMessage = function() {};
+
+/** @constructor */
+google.visualization.Query = function(dataSourceUrl, opt_options) {};
+google.visualization.Query.refreshAllQueries = function() {};
+google.visualization.Query.setResponse = function(response) {};
+google.visualization.Query.prototype.setRefreshInterval = function(intervalSeconds) {};
+google.visualization.Query.prototype.send = function(responseHandler) {};
+google.visualization.Query.prototype.makeRequest = function(responseHandler, opt_params) {};
+google.visualization.Query.prototype.abort = function() {};
+google.visualization.Query.prototype.setTimeout = function(timeoutSeconds) {};
+google.visualization.Query.prototype.setRefreshable = function(refreshable) {};
+google.visualization.Query.prototype.setQuery = function(queryString) {};
+
+google.visualization.errors = {};
+google.visualization.errors.addError = function(container, message, opt_detailedMessage, opt_options) {};
+google.visualization.errors.removeAll = function(container) {};
+google.visualization.errors.addErrorFromQueryResponse = function(container, response) {};
+google.visualization.errors.removeError = function(id) {};
+google.visualization.errors.getContainer = function(errorId) {};
+
+google.visualization.events = {};
+google.visualization.events.addListener = function(eventSource, eventName, eventHandler) {};
+google.visualization.events.trigger = function(eventSource, eventName, eventDetails) {};
+google.visualization.events.removeListener = function(listener) {};
+google.visualization.events.removeAllListeners = function(eventSource) {};
+
+/** @constructor */
+google.visualization.DataView = function(dataTable) {};
+google.visualization.DataView.fromJSON = function(dataTable, view) {};
+google.visualization.DataView.prototype.setColumns = function(colIndices) {};
+google.visualization.DataView.prototype.setRows = function(arg0, opt_arg1) {};
+google.visualization.DataView.prototype.getViewColumns = function() {};
+google.visualization.DataView.prototype.getViewRows = function() {};
+google.visualization.DataView.prototype.hideColumns = function(colIndices) {};
+google.visualization.DataView.prototype.hideRows = function(arg0, opt_arg1) {};
+google.visualization.DataView.prototype.getViewColumnIndex = function(tableColumnIndex) {};
+google.visualization.DataView.prototype.getViewRowIndex = function(tableRowIndex) {};
+google.visualization.DataView.prototype.getTableColumnIndex = function(viewColumnIndex) {};
+google.visualization.DataView.prototype.getUnderlyingTableColumnIndex = function(viewColumnIndex) {};
+google.visualization.DataView.prototype.getTableRowIndex = function(viewRowIndex) {};
+google.visualization.DataView.prototype.getUnderlyingTableRowIndex = function(viewRowIndex) {};
+google.visualization.DataView.prototype.getNumberOfRows = function() {};
+google.visualization.DataView.prototype.getNumberOfColumns = function() {};
+google.visualization.DataView.prototype.getColumnId = function(columnIndex) {};
+google.visualization.DataView.prototype.getColumnIndex = function(columnId) {};
+google.visualization.DataView.prototype.getColumnLabel = function(columnIndex) {};
+google.visualization.DataView.prototype.getColumnPattern = function(columnIndex) {};
+google.visualization.DataView.prototype.getColumnRole = function(columnIndex) {};
+google.visualization.DataView.prototype.getColumnType = function(columnIndex) {};
+google.visualization.DataView.prototype.getValue = function(rowIndex, columnIndex) {};
+google.visualization.DataView.prototype.getFormattedValue = function(rowIndex, columnIndex) {};
+google.visualization.DataView.prototype.getProperty = function(rowIndex, columnIndex, property) {};
+google.visualization.DataView.prototype.getColumnProperty = function(columnIndex, property) {};
+google.visualization.DataView.prototype.getColumnProperties = function(columnIndex) {};
+google.visualization.DataView.prototype.getTableProperty = function(property) {};
+google.visualization.DataView.prototype.getTableProperties = function() {};
+google.visualization.DataView.prototype.getRowProperty = function(rowIndex, property) {};
+google.visualization.DataView.prototype.getRowProperties = function(rowIndex) {};
+google.visualization.DataView.prototype.getColumnRange = function(columnIndex) {};
+google.visualization.DataView.prototype.getDistinctValues = function(columnIndex) {};
+google.visualization.DataView.prototype.getSortedRows = function(sortColumns) {};
+google.visualization.DataView.prototype.getFilteredRows = function(columnFilters) {};
+google.visualization.DataView.prototype.toDataTable = function() {};
+
+/** @return {string} JSON representation. */
+google.visualization.DataView.prototype.toJSON = function() {};
+
+/** @constructor */
+google.visualization.ArrowFormat = function(opt_options) {};
+google.visualization.ArrowFormat.prototype.format = function(dataTable, columnIndex) {};
+
+/** @constructor */
+google.visualization.BarFormat = function(opt_options) {};
+google.visualization.BarFormat.prototype.format = function(dataTable, columnIndex) {};
+
+/** @constructor */
+google.visualization.ColorFormat = function() {};
+google.visualization.ColorFormat.prototype.addRange = function(from, to, color, bgcolor) {};
+google.visualization.ColorFormat.prototype.addGradientRange = function(from, to, color, fromBgColor, toBgColor) {};
+google.visualization.ColorFormat.prototype.format = function(dataTable, columnIndex) {};
+
+/** @constructor */
+google.visualization.DateFormat = function(opt_options) {};
+google.visualization.DateFormat.prototype.format = function(dataTable, columnIndex) {};
+google.visualization.DateFormat.prototype.formatValue = function(value) {};
+
+/** @constructor */
+google.visualization.NumberFormat = function(opt_options) {};
+google.visualization.NumberFormat.prototype.format = function(dataTable, columnIndex) {};
+google.visualization.NumberFormat.prototype.formatValue = function(value) {};
+google.visualization.NumberFormat.DECIMAL_SEP;
+google.visualization.NumberFormat.GROUP_SEP;
+google.visualization.NumberFormat.DECIMAL_PATTERN;
+
+/** @constructor */
+google.visualization.PatternFormat = function(pattern) {};
+google.visualization.PatternFormat.prototype.format = function(dataTable, srcColumnIndices, opt_dstColumnIndex) {};
+
+/** @constructor */
+google.visualization.GadgetHelper = function() {};
+google.visualization.GadgetHelper.prototype.createQueryFromPrefs = function(prefs) {};
+google.visualization.GadgetHelper.prototype.validateResponse = function(response) {};
+
+/** @constructor */
+google.visualization.AnnotatedTimeLine = function(container) {};
+google.visualization.AnnotatedTimeLine.prototype.draw = function(data, opt_options) {};
+google.visualization.AnnotatedTimeLine.prototype.getSelection = function() {};
+google.visualization.AnnotatedTimeLine.prototype.getVisibleChartRange = function() {};
+google.visualization.AnnotatedTimeLine.prototype.setVisibleChartRange = function(firstDate, lastDate, opt_animate) {};
+google.visualization.AnnotatedTimeLine.prototype.showDataColumns = function(columnIndexes) {};
+google.visualization.AnnotatedTimeLine.prototype.hideDataColumns = function(columnIndexes) {};
+
+/** @constructor */
+google.visualization.AreaChart = function(container) {};
+google.visualization.AreaChart.prototype.draw = function(data, opt_options, opt_state) {};
+google.visualization.AreaChart.prototype.clearChart = function() {};
+google.visualization.AreaChart.prototype.getSelection = function() {};
+google.visualization.AreaChart.prototype.setSelection = function(selection) {};
+
+/** @constructor */
+google.visualization.BarChart = function(container) {};
+google.visualization.BarChart.prototype.draw = function(data, opt_options, opt_state) {};
+google.visualization.BarChart.prototype.clearChart = function() {};
+google.visualization.BarChart.prototype.getSelection = function() {};
+google.visualization.BarChart.prototype.setSelection = function(selection) {};
+
+/** @constructor */
+google.visualization.BubbleChart = function(container) {};
+google.visualization.BubbleChart.prototype.draw = function(data, opt_options, opt_state) {};
+google.visualization.BubbleChart.prototype.clearChart = function() {};
+google.visualization.BubbleChart.prototype.getSelection = function() {};
+google.visualization.BubbleChart.prototype.setSelection = function(selection) {};
+
+/** @constructor */
+google.visualization.CandlestickChart = function(container) {};
+google.visualization.CandlestickChart.prototype.draw = function(data, opt_options, opt_state) {};
+google.visualization.CandlestickChart.prototype.clearChart = function() {};
+google.visualization.CandlestickChart.prototype.getSelection = function() {};
+google.visualization.CandlestickChart.prototype.setSelection = function(selection) {};
+
+/** @constructor */
+google.visualization.ColumnChart = function(container) {};
+google.visualization.ColumnChart.prototype.draw = function(data, opt_options, opt_state) {};
+google.visualization.ColumnChart.prototype.clearChart = function() {};
+google.visualization.ColumnChart.prototype.getSelection = function() {};
+google.visualization.ColumnChart.prototype.setSelection = function(selection) {};
+
+/** @constructor */
+google.visualization.ComboChart = function(container) {};
+google.visualization.ComboChart.prototype.draw = function(data, opt_options, opt_state) {};
+google.visualization.ComboChart.prototype.clearChart = function() {};
+google.visualization.ComboChart.prototype.getSelection = function() {};
+google.visualization.ComboChart.prototype.setSelection = function(selection) {};
+
+/** @constructor */
+google.visualization.Gauge = function(container) {};
+google.visualization.Gauge.prototype.draw = function(dataTable, opt_options) {};
+google.visualization.Gauge.prototype.clearChart = function() {};
+
+/** @constructor */
+google.visualization.GeoChart = function(container) {};
+google.visualization.GeoChart.mapExists = function(userOptions) {};
+google.visualization.GeoChart.prototype.clearChart = function() {};
+google.visualization.GeoChart.prototype.draw = function(dataTable, userOptions, opt_state) {};
+google.visualization.GeoChart.prototype.getSelection = function() {};
+google.visualization.GeoChart.prototype.setSelection = function(selection) {};
+
+/** @constructor */
+google.visualization.GeoMap = function(container) {};
+google.visualization.GeoMap.clickOnRegion = function(id, zoomLevel, segmentBy, instanceIndex) {};
+google.visualization.GeoMap.prototype.draw = function(dataTable, opt_options) {};
+google.visualization.GeoMap.prototype.getSelection = function() {};
+google.visualization.GeoMap.prototype.setSelection = function(selection) {};
+
+/** @constructor */
+google.visualization.Map = function(container) {};
+google.visualization.Map.prototype.draw = function(dataTable, opt_options) {};
+google.visualization.Map.prototype.getSelection = function() {};
+google.visualization.Map.prototype.setSelection = function(selection) {};
+
+/** @constructor */
+google.visualization.ImageAreaChart = function(container) {};
+google.visualization.ImageAreaChart.prototype.draw = function(data, opt_options) {};
+
+/** @constructor */
+google.visualization.ImageBarChart = function(container) {};
+google.visualization.ImageBarChart.prototype.draw = function(data, opt_options) {};
+
+/** @constructor */
+google.visualization.ImageCandlestickChart = function(container) {};
+google.visualization.ImageCandlestickChart.prototype.draw = function(data, opt_options) {};
+
+/** @constructor */
+google.visualization.ImageChart = function(container) {};
+google.visualization.ImageChart.prototype.draw = function(data, opt_options) {};
+
+/** @constructor */
+google.visualization.ImageLineChart = function(container) {};
+google.visualization.ImageLineChart.prototype.draw = function(data, opt_options) {};
+
+/** @constructor */
+google.visualization.ImagePieChart = function(container) {};
+google.visualization.ImagePieChart.prototype.draw = function(data, opt_options) {};
+
+/** @constructor */
+google.visualization.ImageSparkLine = function(container, opt_domHelper) {};
+google.visualization.ImageSparkLine.prototype.draw = function(dataTable, opt_options) {};
+google.visualization.ImageSparkLine.prototype.getSelection = function() {};
+google.visualization.ImageSparkLine.prototype.setSelection = function(selection) {};
+
+/** @constructor */
+google.visualization.IntensityMap = function(container) {};
+google.visualization.IntensityMap.prototype.draw = function(dataTable, opt_options) {};
+google.visualization.IntensityMap.prototype.getSelection = function() {};
+google.visualization.IntensityMap.prototype.setSelection = function(selection) {};
+
+/** @constructor */
+google.visualization.LineChart = function(container) {};
+google.visualization.LineChart.prototype.draw = function(data, opt_options, opt_state) {};
+google.visualization.LineChart.prototype.clearChart = function() {};
+google.visualization.LineChart.prototype.getSelection = function() {};
+google.visualization.LineChart.prototype.setSelection = function(selection) {};
+
+/** @constructor */
+google.visualization.MotionChart = function(container) {};
+google.visualization.MotionChart.prototype.draw = function(dataTable, opt_options) {};
+google.visualization.MotionChart.prototype.getState = function() {};
+
+/** @constructor */
+google.visualization.OrgChart = function(container) {};
+google.visualization.OrgChart.prototype.draw = function(dataTable, opt_options) {};
+google.visualization.OrgChart.prototype.getSelection = function() {};
+google.visualization.OrgChart.prototype.setSelection = function(selection) {};
+google.visualization.OrgChart.prototype.getCollapsedNodes = function() {};
+google.visualization.OrgChart.prototype.getChildrenIndexes = function(rowInd) {};
+google.visualization.OrgChart.prototype.collapse = function(rowInd, collapse) {};
+
+/** @constructor */
+google.visualization.PieChart = function(container) {};
+google.visualization.PieChart.prototype.draw = function(data, opt_options, opt_state) {};
+google.visualization.PieChart.prototype.clearChart = function() {};
+google.visualization.PieChart.prototype.getSelection = function() {};
+google.visualization.PieChart.prototype.setSelection = function(selection) {};
+
+/** @constructor */
+google.visualization.ScatterChart = function(container) {};
+google.visualization.ScatterChart.prototype.draw = function(data, opt_options, opt_state) {};
+google.visualization.ScatterChart.prototype.clearChart = function() {};
+google.visualization.ScatterChart.prototype.getSelection = function() {};
+google.visualization.ScatterChart.prototype.setSelection = function(selection) {};
+
+/** @constructor */
+google.visualization.SparklineChart = function(container) {};
+google.visualization.SparklineChart.prototype.draw = function(data, opt_options, opt_state) {};
+google.visualization.SparklineChart.prototype.clearChart = function() {};
+google.visualization.SparklineChart.prototype.getSelection = function() {};
+google.visualization.SparklineChart.prototype.setSelection = function(selection) {};
+
+/** @constructor */
+google.visualization.SteppedAreaChart = function(container) {};
+google.visualization.SteppedAreaChart.prototype.draw = function(data, opt_options, opt_state) {};
+google.visualization.SteppedAreaChart.prototype.clearChart = function() {};
+google.visualization.SteppedAreaChart.prototype.getSelection = function() {};
+google.visualization.SteppedAreaChart.prototype.setSelection = function(selection) {};
+
+/** @constructor */
+google.visualization.Table = function(container) {};
+google.visualization.Table.prototype.draw = function(dataTable, opt_options) {};
+google.visualization.Table.prototype.clearChart = function() {};
+google.visualization.Table.prototype.getSortInfo = function() {};
+google.visualization.Table.prototype.getSelection = function() {};
+google.visualization.Table.prototype.setSelection = function(selection) {};
+
+/** @constructor */
+google.visualization.TreeMap = function(container) {};
+google.visualization.TreeMap.prototype.draw = function(dataTable, opt_options) {};
+google.visualization.TreeMap.prototype.clearChart = function() {};
+google.visualization.TreeMap.prototype.getSelection = function() {};
+google.visualization.TreeMap.prototype.setSelection = function(selection) {};
+
+google.visualization.drawToolbar = function(container, components) {};
+
+/** @constructor */
+google.visualization.ChartWrapper = function(opt_specification) {};
+google.visualization.ChartWrapper.prototype.draw = function(opt_container) {};
+google.visualization.ChartWrapper.prototype.getDataSourceUrl = function() {};
+google.visualization.ChartWrapper.prototype.getDataTable = function() {};
+google.visualization.ChartWrapper.prototype.getChartName = function() {};
+google.visualization.ChartWrapper.prototype.getChartType = function() {};
+google.visualization.ChartWrapper.prototype.getContainerId = function() {};
+google.visualization.ChartWrapper.prototype.getQuery = function() {};
+google.visualization.ChartWrapper.prototype.getRefreshInterval = function() {};
+google.visualization.ChartWrapper.prototype.getView = function() {};
+google.visualization.ChartWrapper.prototype.getOption = function(key, opt_default) {};
+google.visualization.ChartWrapper.prototype.getOptions = function() {};
+google.visualization.ChartWrapper.prototype.setDataSourceUrl = function(dataSourceUrl) {};
+google.visualization.ChartWrapper.prototype.setDataTable = function(dataTable) {};
+google.visualization.ChartWrapper.prototype.setChartName = function(chartName) {};
+google.visualization.ChartWrapper.prototype.setChartType = function(chartType) {};
+google.visualization.ChartWrapper.prototype.setContainerId = function(containerId) {};
+google.visualization.ChartWrapper.prototype.setQuery = function(query) {};
+google.visualization.ChartWrapper.prototype.setRefreshInterval = function(refreshInterval) {};
+google.visualization.ChartWrapper.prototype.setView = function(view) {};
+google.visualization.ChartWrapper.prototype.setOption = function(key, value) {};
+google.visualization.ChartWrapper.prototype.setOptions = function(options) {};
+
+/** @return {string} JSON representation. */
+google.visualization.ChartWrapper.prototype.toJSON = function() {};
+
+/** @constructor */
+google.visualization.ControlWrapper = function(opt_specification) {};
+google.visualization.ControlWrapper.prototype.draw = function(opt_container) {};
+google.visualization.ControlWrapper.prototype.toJSON = function() {};
+google.visualization.ControlWrapper.prototype.getDataSourceUrl = function() {};
+google.visualization.ControlWrapper.prototype.getDataTable = function() {};
+google.visualization.ControlWrapper.prototype.getControlName = function() {};
+google.visualization.ControlWrapper.prototype.getControlType = function() {};
+google.visualization.ControlWrapper.prototype.getContainerId = function() {};
+google.visualization.ControlWrapper.prototype.getQuery = function() {};
+google.visualization.ControlWrapper.prototype.getRefreshInterval = function() {};
+google.visualization.ControlWrapper.prototype.getView = function() {};
+google.visualization.ControlWrapper.prototype.getOption = function(key, opt_default) {};
+google.visualization.ControlWrapper.prototype.getOptions = function() {};
+google.visualization.ControlWrapper.prototype.setDataSourceUrl = function(dataSourceUrl) {};
+google.visualization.ControlWrapper.prototype.setDataTable = function(dataTable) {};
+google.visualization.ControlWrapper.prototype.setControlName = function(controlName) {};
+google.visualization.ControlWrapper.prototype.setControlType = function(controlType) {};
+google.visualization.ControlWrapper.prototype.setContainerId = function(containerId) {};
+google.visualization.ControlWrapper.prototype.setQuery = function(query) {};
+google.visualization.ControlWrapper.prototype.setRefreshInterval = function(refreshInterval) {};
+google.visualization.ControlWrapper.prototype.setView = function(view) {};
+google.visualization.ControlWrapper.prototype.setOption = function(key, value) {};
+google.visualization.ControlWrapper.prototype.setOptions = function(options) {};
+
+/** @return {string} JSON representation. */
+google.visualization.ChartWrapper.prototype.toJSON = function() {};
+
+/** @constructor */
+google.visualization.ChartEditor = function(opt_config) {};
+google.visualization.ChartEditor.prototype.openDialog = function(specification, opt_options) {};
+google.visualization.ChartEditor.prototype.getChartWrapper = function() {};
+google.visualization.ChartEditor.prototype.setChartWrapper = function(chartWrapper) {};
+google.visualization.ChartEditor.prototype.closeDialog = function() {};
+
+/** @constructor */
+google.visualization.Dashboard = function(container) {};
+google.visualization.Dashboard.prototype.bind = function(controls, participants) {};
+google.visualization.Dashboard.prototype.draw = function(dataTable) {};
+
+/** @constructor */
+google.visualization.StringFilter = function(container) {};
+google.visualization.StringFilter.prototype.draw = function(dataTable, opt_options, opt_state) {};
+google.visualization.StringFilter.prototype.applyFilter = function() {};
+google.visualization.StringFilter.prototype.getState = function() {};
+google.visualization.StringFilter.prototype.resetControl = function() {};
+
+/** @constructor */
+google.visualization.NumberRangeFilter = function(container) {};
+google.visualization.NumberRangeFilter.prototype.draw = function(dataTable, opt_options, opt_state) {};
+google.visualization.NumberRangeFilter.prototype.applyFilter = function() {};
+google.visualization.NumberRangeFilter.prototype.getState = function() {};
+google.visualization.NumberRangeFilter.prototype.resetControl = function() {};
+
+/** @constructor */
+google.visualization.CategoryFilter = function(container) {};
+google.visualization.CategoryFilter.prototype.draw = function(dataTable, opt_options, opt_state) {};
+google.visualization.CategoryFilter.prototype.applyFilter = function() {};
+google.visualization.CategoryFilter.prototype.getState = function() {};
+google.visualization.CategoryFilter.prototype.resetControl = function() {};
+
+/** @constructor */
+google.visualization.ChartRangeFilter = function(container) {};
+google.visualization.ChartRangeFilter.prototype.draw = function(dataTable, opt_options, opt_state) {};
+google.visualization.ChartRangeFilter.prototype.applyFilter = function() {};
+google.visualization.ChartRangeFilter.prototype.getState = function() {};
+google.visualization.ChartRangeFilter.prototype.resetControl = function() {};

--- a/client/externs/gviz-api.js
+++ b/client/externs/gviz-api.js
@@ -394,7 +394,6 @@ google.visualization.ChartWrapper.prototype.toJSON = function() {};
 /** @constructor */
 google.visualization.ControlWrapper = function(opt_specification) {};
 google.visualization.ControlWrapper.prototype.draw = function(opt_container) {};
-google.visualization.ControlWrapper.prototype.toJSON = function() {};
 google.visualization.ControlWrapper.prototype.getDataSourceUrl = function() {};
 google.visualization.ControlWrapper.prototype.getDataTable = function() {};
 google.visualization.ControlWrapper.prototype.getControlName = function() {};
@@ -417,7 +416,7 @@ google.visualization.ControlWrapper.prototype.setOption = function(key, value) {
 google.visualization.ControlWrapper.prototype.setOptions = function(options) {};
 
 /** @return {string} JSON representation. */
-google.visualization.ChartWrapper.prototype.toJSON = function() {};
+google.visualization.ControlWrapper.prototype.toJSON = function() {};
 
 /** @constructor */
 google.visualization.ChartEditor = function(opt_config) {};

--- a/client/externs/ui-bootstrap.js
+++ b/client/externs/ui-bootstrap.js
@@ -1,0 +1,284 @@
+/*
+ * Copyright 2014 The Closure Compiler Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Externs for ui-bootstrap.
+ *
+ * API Reference: http://angular-ui.github.io/bootstrap/
+ *
+ * @externs
+ */
+
+
+/**
+ * Suppresses the compiler warning when multiple externs files declare the
+ * ui namespace.
+ * @suppress {duplicate}
+ * @noalias
+ */
+var ui = {};
+
+
+/**
+ * @const
+ */
+ui.bootstrap = {};
+
+/******************************************************************************
+ * $transition Service
+ *****************************************************************************/
+
+
+/**
+ * @typedef {function(!angular.JQLite, !(string|Object|Function),
+ *     Object=):!angular.$q.Promise
+ *     }
+ */
+ui.bootstrap.$transition;
+
+
+/**
+ * Augment the ui.bootstrap.$transition type definition by reopening the type
+ * via an artificial ui.bootstrap.$transition instance.
+ *
+ * This allows us to define methods on function objects which is something
+ * that can't be expressed via typical type annotations.
+ *
+ * @type {ui.bootstrap.$transition}
+ */
+ui.bootstrap.$transition_;
+
+
+/**
+ * @type {(string|undefined)}
+ */
+ui.bootstrap.$transition_.animationEndEventName;
+
+
+/**
+ * @type {(string|undefined)}
+ */
+ui.bootstrap.$transition_.transitionEndEventName;
+
+/******************************************************************************
+ * $modal service
+ *****************************************************************************/
+
+
+/**
+ * @typedef {{
+ *   close: function(*=),
+ *   dismiss: function(*=),
+ *   opened: !angular.$q.Promise,
+ *   result: !angular.$q.Promise
+ * }}
+ */
+ui.bootstrap.modalInstance;
+
+
+/**
+ * @param {*=} opt_result
+ */
+ui.bootstrap.modalInstance.close = function(opt_result) {};
+
+
+/**
+ * @param {*=} opt_reason
+ */
+ui.bootstrap.modalInstance.dismiss = function(opt_reason) {};
+
+
+/**
+ * @type {!angular.$q.Promise}
+ */
+ui.bootstrap.modalInstance.opened;
+
+
+/**
+ * @type {!angular.$q.Promise}
+ */
+ui.bootstrap.modalInstance.result;
+
+
+/**
+ * @typedef {{
+ *   open: function(!Object)
+ * }}
+ */
+ui.bootstrap.$modal;
+
+
+/**
+ * @param {!Object} modalOptions
+ * @return {!ui.bootstrap.modalInstance}
+ */
+ui.bootstrap.$modal.open = function(modalOptions) {};
+
+/******************************************************************************
+ * $modalStack service
+ *****************************************************************************/
+
+
+/**
+ * @typedef {{
+ *   open: function(!Object, !Object),
+ *   close: function(!Object, *=),
+ *   dismiss: function(!Object, *=),
+ *   dismissAll: function(*=),
+ *   getTop: function()
+ * }}
+ */
+ui.bootstrap.$modalStack;
+
+
+/**
+ * @param {!Object} modalInstance
+ * @param {!Object} modal
+ */
+ui.bootstrap.$modalStack.open = function(modalInstance, modal) {};
+
+
+/**
+ * @param {!Object} modalInstance
+ * @param {*=} opt_result
+ */
+ui.bootstrap.$modalStack.close = function(modalInstance, opt_result) {};
+
+
+/**
+ * @param {!Object} modalInstance
+ * @param {*=} opt_reason
+ */
+ui.bootstrap.$modalStack.dismiss = function(modalInstance, opt_reason) {};
+
+
+/**
+ * @param {*=} opt_reason
+ */
+ui.bootstrap.$modalStack.dismissAll = function(opt_reason) {};
+
+
+/**
+ * @return {!ui.bootstrap.modalInstance}
+ */
+ui.bootstrap.$modalStack.getTop = function() {};
+
+
+
+/******************************************************************************
+ * $position service
+ *****************************************************************************/
+
+
+/**
+ * @typedef {{
+ *   position: function(!angular.JQLite),
+ *   offset: function(!angular.JQLite),
+ *   positionElements: function(!angular.JQLite, !angular.JQLite, string,
+ *     (boolean|undefined))
+ *   }}
+ */
+ui.bootstrap.$position;
+
+
+/**
+ * @param {!angular.JQLite} element
+ * @return {{width:number, height:number, top:number, left:number}}
+ */
+ui.bootstrap.$position.position = function(element) {};
+
+
+/**
+ * @param {!angular.JQLite} element
+ * @return {{width:number, height:number, top:number, left:number}}
+ */
+ui.bootstrap.$position.offset = function(element) {};
+
+
+/**
+ * @param {!angular.JQLite} hostEl
+ * @param {!angular.JQLite} targetEl
+ * @param {string} positionStr
+ * @param {boolean=} opt_appendToBody
+ * @return {{width:number, height:number, top:number, left:number}}
+ */
+ui.bootstrap.$position.positionElements = function(hostEl, targetEl,
+    positionStr, opt_appendToBody) {};
+
+
+/******************************************************************************
+ * Tooltip
+ *****************************************************************************/
+
+
+/**
+ * @typedef {{
+ *   compile: (function(!angular.JQLite=, !angular.Attributes=)|undefined),
+ *   restrict: (string|undefined)
+ *   }}
+ */
+ui.bootstrap.Tooltip;
+
+
+/**
+ * @param {!angular.JQLite=} opt_element
+ * @param {!angular.Attributes=} opt_attrs
+ */
+ui.bootstrap.Tooltip.compile = function(opt_element, opt_attrs) {};
+
+
+/**
+ * @type {(string|undefined)}
+ */
+ui.bootstrap.Tooltip.restrict;
+
+/******************************************************************************
+ * $tooltip service
+ *****************************************************************************/
+
+
+/**
+ * @param {string} type
+ * @param {string} prefix
+ * @param {string} defaultTriggerShow
+ * @return {!ui.bootstrap.Tooltip}
+ */
+ui.bootstrap.$tooltip = function(type, prefix, defaultTriggerShow) {};
+
+/******************************************************************************
+ * $tooltipProvider service
+ *****************************************************************************/
+
+
+/**
+ * @typedef {{
+ *   options: function(!Object.<string,(boolean|number|string)>=),
+ *   setTriggers: function(!Object.<string,string>)
+ *   }}
+ */
+ui.bootstrap.$tooltipProvider;
+
+
+/**
+ * @param {!Object.<string,(boolean|number|string)>=} opt_options
+ */
+ui.bootstrap.$tooltipProvider.options = function(opt_options) {};
+
+
+/**
+ * @param {!Object.<string, string>} triggers
+ */
+ui.bootstrap.$tooltipProvider.setTriggers = function(triggers) {};

--- a/client/models/chart_widget_model.js
+++ b/client/models/chart_widget_model.js
@@ -119,7 +119,7 @@ p3rf.perfkit.explorer.models.ChartModel = function() {
   };
 
   /**
-   * @type {!Array.<!ColumnStyleModel}
+   * @type {!Array.<!ColumnStyleModel>}
    * @export
    */
   this.columns = [];

--- a/client/models/perfkit_simple_builder/query_column_model.js
+++ b/client/models/perfkit_simple_builder/query_column_model.js
@@ -229,7 +229,7 @@ explorer.models.perfkit_simple_builder.QueryColumnModel = function() {
   /** @export @type {!PivotConfigModel} */
   this.pivot_config = new PivotConfigModel();
 
-  /** @type @type {?number} */
+  /** @export @type {?number} */
   this.row_limit = null;
 
   /**

--- a/client/models/perfkit_simple_builder/query_config_model.js
+++ b/client/models/perfkit_simple_builder/query_config_model.js
@@ -28,6 +28,7 @@ goog.require('p3rf.perfkit.explorer.models.perfkit_simple_builder.QueryColumnMod
 goog.require('p3rf.perfkit.explorer.models.perfkit_simple_builder.QueryDateGroupings');
 goog.require('p3rf.perfkit.explorer.models.perfkit_simple_builder.QueryFilterModel');
 goog.require('p3rf.perfkit.explorer.models.perfkit_simple_builder.QueryFilterModel');
+goog.require('p3rf.perfkit.explorer.models.perfkit_simple_builder.MetadataFilter');
 
 
 goog.scope(function() {
@@ -40,6 +41,7 @@ const QueryColumnModel = explorer.models.perfkit_simple_builder.QueryColumnModel
 const QueryDateGroupings = explorer.models.perfkit_simple_builder.QueryDateGroupings;
 const QueryFilterModel = explorer.models.perfkit_simple_builder.QueryFilterModel;
 const BigqueryConfigModel = explorer.ext.bigquery.BigqueryConfigModel;
+const MetadataFilter = explorer.models.perfkit_simple_builder.MetadataFilter;
 
 
 /**

--- a/client/models/perfkit_simple_builder/query_filter_model.js
+++ b/client/models/perfkit_simple_builder/query_filter_model.js
@@ -29,6 +29,7 @@ const explorer = p3rf.perfkit.explorer;
 
 /**
  * Describes a label/value pair used in PerfKit sample metadata.
+ * @constructor
  * @export
  */
 p3rf.perfkit.explorer.models.perfkit_simple_builder.MetadataFilter = function() {
@@ -57,7 +58,7 @@ const MetadataFilter = p3rf.perfkit.explorer.models.perfkit_simple_builder.Metad
 
 /**
  * Constants describing the types of filters applied to dates.
- * @enum
+ * @enum {string}
  * @export
  */
 p3rf.perfkit.explorer.models.perfkit_simple_builder.DateFilterType = {

--- a/client/models/perfkit_simple_builder/query_filter_model.js
+++ b/client/models/perfkit_simple_builder/query_filter_model.js
@@ -107,7 +107,7 @@ p3rf.perfkit.explorer.models.perfkit_simple_builder.DateFilter = function(
   /**
    * specify_time determines whether a time component should be added to the date.  It is only used when filter_type
    * is 'CUSTOM', and if not provided, 00:00 (midnight) will be assumed.
-   * @type {!bool}
+   * @type {boolean}
    */
   this.specify_time = opt_specifyTime || false;
 

--- a/client/models/widget_model.js
+++ b/client/models/widget_model.js
@@ -49,7 +49,7 @@ explorer.models.WidgetState = function() {
   this.selected = false;
 
   /**
-   * @type {!google.visualization.DataView}
+   * @type {?google.visualization.DataView}
    * @export
    */
   this.data = null;
@@ -57,7 +57,7 @@ explorer.models.WidgetState = function() {
   /**
    * TODO: Change type to ContainerWidgetConfig when we figure
    * out how to solve the circular dependency.
-   * @type {Object}
+   * @type {?Object}
    * @export
    */
   this.parent = null;

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,6 +1,7 @@
 var gulp = require('gulp');
 
 try {
+  var gulpUtil = require('gulp-util');
   var closureCompiler = require('gulp-closure-compiler');
   var minifyHtml = require('gulp-minify-html');
   var ngHtml2Js = require('gulp-ng-html2js');
@@ -16,6 +17,7 @@ try {
 
 var jsSourceFiles = [
       'client/**/*.js', '!client/**/*_test.js', '!client/karma.conf.js',
+      '!client/externs.js', '!client/externs/**/*.js',
       'lib/closure-library/closure/goog/**/*.js',
       '!lib/closure-library/closure/goog/**/*_test.js'];
 
@@ -99,24 +101,46 @@ gulp.task('common', ['third_party'], function() {
     .pipe(gulp.dest('build'));
 });
 
+var closureCompilerConfig = {
+  compilerPath: 'bin/closure-compiler.jar',
+  fileName: 'build/perfkit_scripts.js',
+  compilerFlags: {
+    angular_pass: true,
+    compilation_level: 'SIMPLE_OPTIMIZATIONS',
+    formatting: 'PRETTY_PRINT',
+    language_in: 'ECMASCRIPT6',
+    language_out: 'ECMASCRIPT5_STRICT',
+    manage_closure_dependencies: true,
+    only_closure_dependencies: true,
+    process_closure_primitives: true,
+    warning_level: 'VERBOSE',
+    jscomp_off: 'missingProperties',
+    externs: [
+      'client/externs.js',
+      'client/externs/gviz-api.js',
+      'client/externs/angular-1.4.js',
+      'client/externs/angular-1.4-http-promise_templated.js',
+      'client/externs/angular-1.4-q_templated.js',
+    ],
+    closure_entry_point: 'p3rf.perfkit.explorer.application.module'
+  }
+};
+
+var showClosureCompilerErrors = function(err) {
+  // Add a line break in the compiler output so that the first
+  // filename doesn't get munged with the generic error message.
+  // This makes it easier for editors to jump to the right
+  // location. Apply the fixup to the first line only (no /g
+  // modifier).
+  gulpUtil.log('***Compiler output:\n' +
+      err.message.replace(/^(Command failed:)?\s*/, '$1\n'));
+};
+
 gulp.task('test', ['common'], function() {
 
   gulp.src(jsSourceFiles)
-    .pipe(closureCompiler({
-      compilerPath: 'bin/closure-compiler.jar',
-      fileName: 'client/perfkit_scripts.js',
-      compilerFlags: {
-        angular_pass: true,
-        compilation_level: 'SIMPLE_OPTIMIZATIONS',
-        language_in: 'ECMASCRIPT6',
-        language_out: 'ECMASCRIPT5',
-        formatting: 'PRETTY_PRINT',
-        manage_closure_dependencies: true,
-        only_closure_dependencies: true,
-        process_closure_primitives: true,
-        closure_entry_point: 'p3rf.perfkit.explorer.application.module'
-      }
-    }))
+    .pipe(closureCompiler(closureCompilerConfig))
+    .on('error', showClosureCompilerErrors)
     .pipe(gulp.dest('deploy'));
 
   gulp.src('server/**/*.html')
@@ -135,21 +159,8 @@ gulp.task('test', ['common'], function() {
 gulp.task('prod', ['common'], function() {
 
   gulp.src(jsSourceFiles)
-    .pipe(closureCompiler({
-      compilerPath: 'bin/closure-compiler.jar',
-      fileName: 'build/perfkit_scripts.js',
-      compilerFlags: {
-        angular_pass: true,
-        compilation_level: 'SIMPLE_OPTIMIZATIONS',
-        formatting: 'PRETTY_PRINT',
-        language_in: 'ECMASCRIPT6',
-        language_out: 'ECMASCRIPT5_STRICT',
-        manage_closure_dependencies: true,
-        only_closure_dependencies: true,
-        process_closure_primitives: true,
-        closure_entry_point: 'p3rf.perfkit.explorer.application.module'
-      }
-    }))
+    .pipe(closureCompiler(closureCompilerConfig))
+    .on('error', showClosureCompilerErrors)
     .pipe(flatten())
     .pipe(gulp.dest('deploy/client'));
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -117,10 +117,12 @@ var closureCompilerConfig = {
     jscomp_off: 'missingProperties',
     externs: [
       'client/externs.js',
-      'client/externs/gviz-api.js',
-      'client/externs/angular-1.4.js',
       'client/externs/angular-1.4-http-promise_templated.js',
+      'client/externs/angular-1.4.js',
       'client/externs/angular-1.4-q_templated.js',
+      'client/externs/angular-ui-router.js',
+      'client/externs/gviz-api.js',
+      'client/externs/ui-bootstrap.js',
     ],
     closure_entry_point: 'p3rf.perfkit.explorer.application.module'
   }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -120,7 +120,7 @@ var closureCompilerConfig = {
       'client/externs/angular-1.4-http-promise_templated.js',
       'client/externs/angular-1.4.js',
       'client/externs/angular-1.4-q_templated.js',
-      'client/externs/angular-ui-router.js',
+      'client/externs/angular_ui_router.js',
       'client/externs/gviz-api.js',
       'client/externs/ui-bootstrap.js',
     ],

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "author": "Joe Allan Muharsky <jmuharsky@gmail.com>",
   "dependencies": {
     "gulp": "3.9.x",
+    "gulp-util": "3.0.x",
     "gulp-closure-compiler": "0.2.x",
     "gulp-concat": "2.6.x",
     "gulp-flatten": "0.2.x",


### PR DESCRIPTION
This is not complete, I've fixed ~500 of 600 type warnings, mainly missing imports and superficial errors.

This includes a few code changes where the fix was fairly obvious. I've kept these in individual commits for easier reviewing.

The remaining warnings are cases where it wasn't immediately obvious how to fix them, for example
type declarations where I was unsure which type was intended, or genuine mismatches such as missing arguments and inconsistent types. 