### PR TITLE
Workaround for flex layout problems on Chrome 48

### DIFF
--- a/client/components/widget/query/widget-editor-directive.css
+++ b/client/components/widget/query/widget-editor-directive.css
@@ -47,6 +47,10 @@
   box-shadow: 0 4px 16px rgba(0,0,0,0.2);
   -moz-box-shadow: 0 4px 16px rgba(0,0,0,0.2);
   -webkit-box-shadow: 0 4px 16px rgba(0,0,0,0.2);
+
+  /* Bug workaround for http://crbug.com/546034 - flex issues on Chrome 48 */
+  min-width: 0;
+  min-height: 0;
 }
 
 .pk-footer-body {
@@ -61,4 +65,3 @@
   overflow-y: auto;
   overflow-x: auto;
 }
-


### PR DESCRIPTION
From http://crbug.com/546034#c6 :

[IF THIS BREAKS ANY CONTENT/CHROME UI: Please do not revert this change.
Instead, add "min-width: 0; min-height: 0; to your flex items, which
should fix any issues that may occur]