### PR TITLE
Update the flex-for-Chrome-48 fix to handle widget deletion also.

### DIFF
--- a/client/components/widget/query/widget-editor-directive.css
+++ b/client/components/widget/query/widget-editor-directive.css
@@ -47,10 +47,6 @@
   box-shadow: 0 4px 16px rgba(0,0,0,0.2);
   -moz-box-shadow: 0 4px 16px rgba(0,0,0,0.2);
   -webkit-box-shadow: 0 4px 16px rgba(0,0,0,0.2);
-
-  /* Bug workaround for http://crbug.com/546034 - flex issues on Chrome 48 */
-  min-width: 0;
-  min-height: 0;
 }
 
 .pk-footer-body {

--- a/client/css/base.css
+++ b/client/css/base.css
@@ -58,6 +58,16 @@
   display: -webkit-flex;
 }
 
+/* Bug workaround for http://crbug.com/546034 - flex issues on Chrome 48 */
+[layout="row"] > [flex="0"],
+[layout="row"] > [flex=""] {
+  min-width: 0;
+}
+[layout="column"] > [flex="0"],
+[layout="column"] > [flex=""] {
+  min-height: 0;
+}
+
 .pull-right {
   float: right;
 }


### PR DESCRIPTION
Replace the hack specific to the bottom SQL editor with a more generic
fix.