### PR TITLE
Fix viewSQL usage of rewriteQuery

### DIFF
--- a/client/components/dashboard/dashboard-service.js
+++ b/client/components/dashboard/dashboard-service.js
@@ -548,6 +548,7 @@ DashboardService.prototype.selectContainer = function(
  * @param {!bool=} replaceParams If true, parameters (%%NAME%%) will be
  *     replaced with the current param value (from the dashboard or url).
  *     Defaults to false.
+ * @return {string} Rewritten query.
  */
 DashboardService.prototype.rewriteQuery = function(widget, replaceParams) {
   goog.asserts.assert(widget, 'Bad parameters: widget is missing.');

--- a/client/components/explorer/explorer-service.js
+++ b/client/components/explorer/explorer-service.js
@@ -287,7 +287,7 @@ ExplorerService.prototype.viewSql = function(rewrite) {
   }
 
   if (rewrite === true && !widget.model.datasource.custom_query) {
-    this.dashboard.rewriteQuery(widget);
+    widget.model.datasource.query = this.dashboard.rewriteQuery(widget);
   }
 
   this.model.code_editor.isOpen = true;


### PR DESCRIPTION
The code appeared to be calling rewriteQuery for side effect,
discarding the freshly constructed query. Clarify the API
to document the return value and use it.