### PR TITLE
Move query-rebuilding logic, apply when refreshing.

### DIFF
--- a/client/components/dashboard/dashboard-service.js
+++ b/client/components/dashboard/dashboard-service.js
@@ -585,6 +585,28 @@ DashboardService.prototype.rewriteQuery = function(widget, replaceParams) {
         project_name, dataset_name, table_name, table_partition, params);
 };
 
+/**
+ * Rebuilds the current widget's query based on the config.
+ *
+ * If the query is a custom query, it will rewrite .query_exec to replace
+ * parameter tokens with values.  If the query is a Query Builder query,
+ * it will rewrite .query tokens, and .query_exec with values.
+ *
+ * @param {!WidgetConfig} widget The widget to rewrite the query against.
+ */
+DashboardService.prototype.rebuildQuery = function(widget) {
+  if (widget.model.datasource.custom_query !== true) {
+    widget.model.datasource.query = (
+        this.rewriteQuery(widget, false));
+    widget.model.datasource.query_exec = (
+        this.rewriteQuery(widget, true));
+  } else {
+    widget.model.datasource.query_exec = (
+        this.queryBuilderService_.replaceTokens(widget.model.datasource.query,
+                                          this.params));
+  }
+};
+
 
 /**
  * Updates the widget's query, if applicable, and changes the widget
@@ -594,6 +616,7 @@ DashboardService.prototype.rewriteQuery = function(widget, replaceParams) {
  * @export
  */
 DashboardService.prototype.refreshWidget = function(widget) {
+  this.rebuildQuery(widget);
   if (widget.model.datasource.query) {
     this.timeout_(function() {
       widget.state().datasource.status = ResultsDataStatus.TOFETCH;

--- a/client/components/widget/data_viz/gviz/gviz-directive.js
+++ b/client/components/widget/data_viz/gviz/gviz-directive.js
@@ -304,23 +304,10 @@ explorer.components.widget.data_viz.gviz.gvizChart = function(
       /**
        * Applies the current parameters to the widget's query.
        *
-       * If the query is a custom query, it will rewrite .query_exec to replace
-       * parameter tokens with values.  If the query is a Query Builder query,
-       * it will rewrite .query tokens, and .query_exec with values.
        * @export
        */
       scope.applyParameters = function() {
-        let widget = scope.widgetConfig;
-        if (widget.model.datasource.custom_query !== true) {
-          widget.model.datasource.query = (
-              dashboardService.rewriteQuery(widget, false));
-          widget.model.datasource.query_exec = (
-              dashboardService.rewriteQuery(widget, true));
-        } else {
-          widget.model.datasource.query_exec = (
-              queryBuilderService.replaceTokens(widget.model.datasource.query,
-              dashboardService.params));
-        }
+        dashboardService.rebuildQuery(scope.widgetConfig);
       };
 
       // When the datasource status change


### PR DESCRIPTION
Commit b1c9805 had removed duplicated logic from refreshWidget,
but this code appears to be required. Move the code and use it
from both refreshWidget and applyParameters.

For a freshly-created QueryBuilder graph, applyParameters never
gets called since it's conditional on datasource.query being
nonempty, so the query needs to be created in refreshWidget.