### PR TITLE
Confirm on widget delete

### DIFF
--- a/client/app.js
+++ b/client/app.js
@@ -79,6 +79,7 @@ goog.require('p3rf.perfkit.explorer.components.widget.data_viz.gviz.column_style
 goog.require('p3rf.perfkit.explorer.components.widget.data_viz.WidgetEditorCtrl');
 goog.require('p3rf.perfkit.explorer.components.widget.perfkitWidget');
 goog.require('p3rf.perfkit.explorer.components.widget.WidgetConfigDirective');
+goog.require('p3rf.perfkit.explorer.components.widget.WidgetService');
 goog.require('p3rf.perfkit.explorer.components.widget.WidgetStatisticsDirective');
 goog.require('p3rf.perfkit.explorer.components.widget.query.builder.FieldCubeDataService');
 goog.require('p3rf.perfkit.explorer.components.widget.query.builder.MetadataPickerDirective');
@@ -198,6 +199,8 @@ explorer.application.module.service('picklistService',
     explorer.components.widget.query.picklist.PicklistService);
 explorer.application.module.service('widgetFactoryService',
     explorer.components.widget.WidgetFactoryService);
+explorer.application.module.service('widgetService',
+    explorer.components.widget.WidgetService);
 explorer.application.module.service('queryBuilderService',
     explorer.components.widget.query.builder.QueryBuilderService);
 explorer.application.module.service('dashboardAdminPageService',

--- a/client/components/dashboard/dashboard-directive.html
+++ b/client/components/dashboard/dashboard-directive.html
@@ -22,7 +22,7 @@
           <div class="pk-widget-toolbar">
             <span class="glyphicon glyphicon-remove pk-widget-button"
                   ng-hide="explorerSvc.model.readOnly"
-                  ng-click="$event.stopPropagation(); dashboardSvc.removeWidget(widget, container)"></span>
+                  ng-click="removeWidget($event, widget, container)"></span>
             <span class="glyphicon glyphicon-refresh pk-widget-button"
                   ng-show="widget.model.type === widgetFactorySvc.widgetTypes.CHART"
                   ng-click="clickRefreshWidget($event, widget)"></span>

--- a/client/components/dashboard/dashboard-directive.js
+++ b/client/components/dashboard/dashboard-directive.js
@@ -27,13 +27,13 @@ goog.require('p3rf.perfkit.explorer.models.ChartType');
 goog.scope(function() {
 const explorer = p3rf.perfkit.explorer;
 const ChartType = explorer.models.ChartType;
-const DashboardService = explorer.components.dashboard.DashboardService;
 
 
 /**
  * See module docstring for more information about purpose and usage.
  *
  * @return {Object} Directive definition object.
+ * @constructor
  * @ngInject
  */
 explorer.components.dashboard.DashboardDirective = function() {
@@ -47,9 +47,9 @@ explorer.components.dashboard.DashboardDirective = function() {
     templateUrl: '/static/components/dashboard/dashboard-directive.html',
     controller: [
         '$scope', 'explorerService', 'dashboardService', 'containerService', 'sidebarTabService',
-        'widgetFactoryService',
+        'widgetFactoryService', 'widgetService',
         function($scope, explorerService, dashboardService, containerService, sidebarTabService,
-            widgetFactoryService) {
+            widgetFactoryService, widgetService) {
       /** @export */
       $scope.containerSvc = containerService;
 
@@ -88,24 +88,13 @@ explorer.components.dashboard.DashboardDirective = function() {
       $scope.removeWidget = function(event, widget, container) {
         event.stopPropagation();
 
-        if (!window.confirm('The widget will be deleted.')) {
+        let msg = widgetService.getDeleteWarningMessage(widget);
+
+        if (!window.confirm(msg)) {
           return;
         }
 
         dashboardService.removeWidget(widget, container)
-      }
-
-      /** @export */
-      $scope.getSelectedClass = function(container) {
-        if (container.state().selected) {
-          if (explorerStateService.widgets.selected) {
-            return 'pk-container-selected-partial';
-          } else {
-            return 'pk-container-selected';
-          }
-        }
-        
-        return '';
       }
 
       /**

--- a/client/components/dashboard/dashboard-directive.js
+++ b/client/components/dashboard/dashboard-directive.js
@@ -83,7 +83,31 @@ explorer.components.dashboard.DashboardDirective = function() {
 
         sidebarTabService.resolveSelectedTabForWidget();
       }
-      
+
+      /** @export */
+      $scope.removeWidget = function(event, widget, container) {
+        event.stopPropagation();
+
+        if (!window.confirm('The widget will be deleted.')) {
+          return;
+        }
+
+        dashboardService.removeWidget(widget, container)
+      }
+
+      /** @export */
+      $scope.getSelectedClass = function(container) {
+        if (container.state().selected) {
+          if (explorerStateService.widgets.selected) {
+            return 'pk-container-selected-partial';
+          } else {
+            return 'pk-container-selected';
+          }
+        }
+        
+        return '';
+      }
+
       /**
        * Returns true if the widget should scroll its overflow, otherwise stretch.
        * @param {!WidgetConfig} widget

--- a/client/components/widget/widget-service.js
+++ b/client/components/widget/widget-service.js
@@ -1,0 +1,65 @@
+/**
+ * @copyright Copyright 2016 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @fileoverview widgetService is an angular service that provides
+ * utility and management functions for operating on widgets.
+ * @author joemu@google.com (Joe Allan Muharsky)
+ */
+
+goog.provide('p3rf.perfkit.explorer.components.widget.WidgetService');
+
+goog.require('p3rf.perfkit.explorer.components.container.ContainerWidgetConfig');
+goog.require('p3rf.perfkit.explorer.models.WidgetConfig');
+
+
+goog.scope(function() {
+const explorer = p3rf.perfkit.explorer;
+const WidgetConfig = explorer.models.WidgetConfig;
+
+
+
+/**
+ * See module docstring for more information about purpose and usage.
+ *
+ * @constructor
+ */
+explorer.components.widget.WidgetService = class {
+  constructor() {
+    /** @export {string} */
+    this.WIDGET_DELETE_WARNING = 'The widget will be deleted:\n\n';
+  };
+
+  /**
+   * Returns the delete warning for a widget.
+   *
+   * @param {!WidgetConfig} widget
+   * @return {string}
+   */
+  getDeleteWarningMessage(widget) {
+    let widgetName = '';
+    
+    if (widget.model.title) {
+      widgetName = '\'' + widget.model.title + '\'';
+    } else {
+      widgetName = 'Untitled';
+    }
+
+    return this.WIDGET_DELETE_WARNING + widgetName;
+  };
+};
+const WidgetService = explorer.components.widget.WidgetService;
+
+
+});  // goog.scope

--- a/client/components/widget/widget-service_test.js
+++ b/client/components/widget/widget-service_test.js
@@ -1,0 +1,71 @@
+/**
+ * @copyright Copyright 2016 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @fileoverview Tests for the widgetService service.
+ * @author joemu@google.com (Joe Allan Muharsky)
+ */
+
+goog.require('p3rf.perfkit.explorer.application.module');
+goog.provide('p3rf.perfkit.explorer.models.ChartWidgetConfig');
+goog.require('p3rf.perfkit.explorer.components.widget.WidgetService');
+
+
+describe('widgetService', function() {
+  var explorer = p3rf.perfkit.explorer;
+  var gviz = explorer.components.widget.data_viz.gviz;
+
+  var svc, providedConfig;
+  var widgetFactorySvc;
+
+  var ChartWidgetConfig = p3rf.perfkit.explorer.models.ChartWidgetConfig;
+
+  beforeEach(module('explorer'));
+
+  beforeEach(inject(function(widgetService, widgetFactoryService) {
+    svc = widgetService;
+    widgetFactorySvc = widgetFactoryService;
+  }));
+
+  beforeEach(function() {
+    providedConfig = new ChartWidgetConfig(widgetFactorySvc);
+  });
+
+  describe('constructor', function() {
+
+    it('should provide a message template for the widget delete warning', function() {
+      expect(svc.WIDGET_DELETE_WARNING).toEqual('The widget will be deleted:\n\n');
+    });
+  });
+
+  describe('getDeleteWarningMessage', function() {
+
+    it('should return a quoted widget title when one is specified', function() {
+      var providedTitle = 'PROVIDED_TITLE';
+      providedConfig.model.title = providedTitle;
+
+      var actualMessage = svc.getDeleteWarningMessage(providedConfig);
+      var expectedMessage = svc.WIDGET_DELETE_WARNING + '\'' + providedTitle + '\'';
+
+      expect(actualMessage).toEqual(expectedMessage);
+    });
+
+    it('should return untitled when no title is specified ', function() {
+      var actualMessage = svc.getDeleteWarningMessage(providedConfig);
+      var expectedMessage = svc.WIDGET_DELETE_WARNING + 'Untitled';
+
+      expect(actualMessage).toEqual(expectedMessage);
+    });
+  });
+});

--- a/client/components/widget/widget-toolbar-directive.js
+++ b/client/components/widget/widget-toolbar-directive.js
@@ -13,12 +13,17 @@
 
 goog.provide('p3rf.perfkit.explorer.components.widget.WidgetToolbarDirective');
 
+goog.require('p3rf.perfkit.explorer.components.dashboard.DashboardService');
+goog.require('p3rf.perfkit.explorer.components.explorer.ExplorerService');
 goog.require('p3rf.perfkit.explorer.components.explorer.sidebar.SidebarTabService');
+goog.require('p3rf.perfkit.explorer.components.widget.WidgetService');
 
 
 goog.scope(function() {
   const explorer = p3rf.perfkit.explorer;
-
+  const DashboardService = explorer.components.dashboard.DashboardService;
+  const ExplorerService = explorer.components.explorer.ExplorerService;
+  const WidgetService = explorer.components.widget.WidgetService;
 
   /**
    * See module docstring for more information about purpose and usage.
@@ -27,7 +32,7 @@ goog.scope(function() {
    * @ngInject
    */
   explorer.components.widget.WidgetToolbarDirective = function(
-      dashboardService, explorerService) {
+      dashboardService, explorerService, widgetService) {
     return {
       restrict: 'E',
       replace: true,
@@ -90,12 +95,14 @@ goog.scope(function() {
 
         /** @export */
         this.removeSelectedWidget = function() {
-          if (!window.confirm('The selected widget will be deleted.')) {
+          let target = this.dashboardSvc.selectedWidget;
+          let msg = widgetService.getDeleteWarningMessage(target);
+
+          if (!window.confirm(msg)) {
             return;
           }
 
-          this.dashboardSvc.removeWidget(
-              this.dashboardSvc.selectedWidget, this.dashboardSvc.selectedContainer);
+          this.dashboardSvc.removeWidget(target, this.dashboardSvc.selectedContainer);
         };
 
         /** @export */

--- a/client/components/widget/widget-toolbar-directive_test.js
+++ b/client/components/widget/widget-toolbar-directive_test.js
@@ -185,70 +185,84 @@ describe('WidgetToolbarDirective', function() {
         targetElement.click();
         expect(actualController.moveWidgetToNextContainer).toHaveBeenCalled();
       });
+    });
 
-      it('show the widget sql panel', function() {
-        var targetElement = actualElement.find(
-            'button.widget-sql-show');
-        expect(targetElement.length).toBe(1);
+    it('show the widget sql panel', function() {
+      var targetElement = actualElement.find(
+          'button.widget-sql-show');
+      expect(targetElement.length).toBe(1);
 
-        spyOn(explorerService, 'viewSql');
-        targetElement.click();
-        expect(explorerService.viewSql).toHaveBeenCalled();
-      });
+      spyOn(explorerService, 'viewSql');
+      targetElement.click();
+      expect(explorerService.viewSql).toHaveBeenCalled();
+    });
 
-      it('use the sql builder', function() {
-        var targetElement = actualElement.find(
-            'button.widget-sql-build');
-        expect(targetElement.length).toBe(1);
+    it('use the sql builder', function() {
+      var targetElement = actualElement.find(
+          'button.widget-sql-build');
+      expect(targetElement.length).toBe(1);
 
-        spyOn(explorerService, 'restoreBuilder');
-        targetElement.click();
-        expect(explorerService.restoreBuilder).toHaveBeenCalled();
-      });
+      spyOn(explorerService, 'restoreBuilder');
+      targetElement.click();
+      expect(explorerService.restoreBuilder).toHaveBeenCalled();
+    });
 
-      it('show the widget json panel', function() {
-        var targetElement = actualElement.find(
-            'button.widget-json-show');
-        expect(targetElement.length).toBe(1);
+    it('show the widget json panel', function() {
+      var targetElement = actualElement.find(
+          'button.widget-json-show');
+      expect(targetElement.length).toBe(1);
 
-        spyOn(explorerService, 'editJson');
-        targetElement.click();
-        expect(explorerService.editJson).toHaveBeenCalled();
-      });
+      spyOn(explorerService, 'editJson');
+      targetElement.click();
+      expect(explorerService.editJson).toHaveBeenCalled();
+    });
 
-      it('remove the selected widget', function() {
-        var targetElement = actualElement.find(
-            'button.widget-delete');
-        expect(targetElement.length).toBe(1);
+    it('remove the selected widget', function() {
+      var targetElement = actualElement.find(
+          'button.widget-delete');
+      expect(targetElement.length).toBe(1);
 
-        spyOn(actualController, 'removeSelectedWidget');
-        targetElement.click();
-        expect(actualController.removeSelectedWidget).toHaveBeenCalled();
-      });
+      spyOn(actualController, 'removeSelectedWidget');
+      targetElement.click();
+      expect(actualController.removeSelectedWidget).toHaveBeenCalled();
+    });
+  });
+  
+  describe('.removeSelectedWidget', function() {
+    var targetElement;
 
-      it('call the remove method when the user confirms the action', function() {
-        var targetElement = actualElement.find(
-            'button.widget-delete');
-        expect(targetElement.length).toBe(1);
+    beforeEach(inject(function() {
+      actualElement = angular.element('<widget-toolbar />');
+      $compile(actualElement)(scope);
 
-        spyOn(window, 'confirm').and.returnValue(true);
+      scope.$digest();
 
-        spyOn(dashboardService, 'removeWidget');
-        targetElement.click();
-        expect(dashboardService.removeWidget).toHaveBeenCalled();
-      });
+      targetElement = actualElement.find('button.widget-delete');
+      actualController = actualElement.controller('widgetToolbar');
+    }));
 
-      it('do nothing when the user does not confirm the action', function() {
-        var targetElement = actualElement.find(
-            'button.widget-delete');
-        expect(targetElement.length).toBe(1);
+    it('should show a dialog with a the widget title.', function() {
+      spyOn(window, 'confirm').and.returnValue(false);
+      targetElement.click();
 
-        spyOn(window, 'confirm').and.returnValue(false);
+      var expectedMessage = 'The widget will be deleted:\n\nUntitled';
+      expect(window.confirm).toHaveBeenCalledWith(expectedMessage);
+    });
 
-        spyOn(dashboardService, 'removeWidget');
-        targetElement.click();
-        expect(dashboardService.removeWidget).not.toHaveBeenCalled();
-      });
+    it('should call the remove method when the user confirms the action', function() {
+      spyOn(window, 'confirm').and.returnValue(true);
+
+      spyOn(dashboardService, 'removeWidget');
+      targetElement.click();
+      expect(dashboardService.removeWidget).toHaveBeenCalled();
+    });
+
+    it('should do nothing when the user does not confirm the action', function() {
+      spyOn(window, 'confirm').and.returnValue(false);
+
+      spyOn(dashboardService, 'removeWidget');
+      targetElement.click();
+      expect(dashboardService.removeWidget).not.toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
When deleting a widget from the toolbar or the widget itself, show a confirmation dialog that includes the widget title, if provided.