### PR TITLE
Open widget URL's in a new window.

### DIFF
--- a/client/components/dashboard/dashboard-directive.html
+++ b/client/components/dashboard/dashboard-directive.html
@@ -27,6 +27,7 @@
                   ng-show="widget.model.type === widgetFactorySvc.widgetTypes.CHART"
                   ng-click="clickRefreshWidget($event, widget)"></span>
             <a class="pk-widget-button"
+               target="_blank"
                ng-show="widget.model.url"
                ng-click="$event.stopPropagation()"
                ng-href="{{ dashboardSvc.replaceTokens(widget.model.url) }}">


### PR DESCRIPTION
Prevents loss of dashboard data due to inadvertent link clicking.