### PR TITLE
Fix Closure compiler path.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -103,7 +103,7 @@ gulp.task('common', ['third_party'], function() {
 
 var closureCompilerConfig = {
   compilerPath: 'bin/closure-compiler.jar',
-  fileName: 'build/perfkit_scripts.js',
+  fileName: 'deploy/client/perfkit_scripts.js',
   compilerFlags: {
     angular_pass: true,
     compilation_level: 'SIMPLE_OPTIMIZATIONS',


### PR DESCRIPTION
The Closure compiler warnings patch had the wrong destination for its output, so recompiling didn't properly update the code. Fix the path.