### PR TITLE
Add error messaging to pivot DuplicateValueError failures

### DIFF
--- a/server/perfkit/common/big_query_result_pivot.py
+++ b/server/perfkit/common/big_query_result_pivot.py
@@ -173,10 +173,9 @@ class BigQueryPivotTransformer(object):
 
       # If the target cell already has a value, throw an error.
       if self.transformed_rows[row_index]['f'][column_index]['v']:
-        logging.error(
-            'Pivot failed: value already exists at row "%s", col "%s".',
-            row_name, column_name)
-        raise DuplicateValueError()
+        msg = 'Pivot failed: value already exists at row "%s", col "%s".' % (row_name, column_name)
+        logging.error(msg)
+        raise DuplicateValueError(msg)
 
       # Set the value of the target cell.
       self.transformed_rows[row_index]['f'][column_index]['v'] = value

--- a/server/perfkit/common/big_query_result_pivot.py
+++ b/server/perfkit/common/big_query_result_pivot.py
@@ -173,7 +173,10 @@ class BigQueryPivotTransformer(object):
 
       # If the target cell already has a value, throw an error.
       if self.transformed_rows[row_index]['f'][column_index]['v']:
-        msg = 'Pivot failed: value already exists at row "%s", col "%s".' % (row_name, column_name)
+        msg = (
+            'Pivot failed: value already exists at row "%s", col "%s". '
+            'Pivots require data to be pre-aggregated; each row/col combination '
+            'can only appear once.' % (row_name, column_name))
         logging.error(msg)
         raise DuplicateValueError(msg)
 

--- a/server/perfkit/explorer/handlers/data.py
+++ b/server/perfkit/explorer/handlers/data.py
@@ -299,8 +299,10 @@ class SqlDataHandler(base.RequestHandlerBase):
     # return JSON with descriptive text so that we can give the user a
     # constructive error message.
     # TODO: Formalize error reporting/handling across the application.
-    except (big_query_client.BigQueryError, ValueError, KeyError, SecurityError) as err:
-      self.RenderJson({'error': err.message})
+    except (big_query_client.BigQueryError, big_query_result_pivot.DuplicateValueError,
+            ValueError, KeyError, SecurityError) as err:
+      logging.error(str(err))
+      self.RenderJson({'error': str(err)})
     except MySQLdb.OperationalError as err:
       self.RenderJson({'error': 'MySQLdb error %s' % str(err)})
     except (google.appengine.runtime.DeadlineExceededError,


### PR DESCRIPTION
This resolves an issue where certain pivot errors were returning an empty string.