### PR TITLE
Add width/height offset for chart sizing to deal with Linux/Chrome Issue

### DIFF
--- a/client/components/widget/data_viz/gviz/gviz-directive.js
+++ b/client/components/widget/data_viz/gviz/gviz-directive.js
@@ -62,6 +62,13 @@ const ResultsDataStatus = explorer.models.ResultsDataStatus;
 const WorkQueueService = explorer.components.util.WorkQueueService;
 
 
+// TODO: Determine why Linux and OSX Chrome versions treat chart sizing differently.
+/** @type {number} Specifies the number of pixels that the chart's width needs to be reduced by. */
+const CHART_EXTRA_WIDTH_PX = 16;
+/** @type {number} Specifies the number of pixels that the chart's width needs to be reduced by. */
+const CHART_EXTRA_HEIGHT_PX = 16;
+
+
 /**
  * See module docstring for more information about purpose and usage.
  *
@@ -220,7 +227,7 @@ explorer.components.widget.data_viz.gviz.gvizChart = function(
         if (scope.widgetConfig.model.chart) {
           if (isHeightEnforced()) {
             scope.widgetConfig.state().chart.height =
-                scope.widgetConfig.state().parent.model.container.height;
+                scope.widgetConfig.state().parent.model.container.height - CHART_EXTRA_HEIGHT_PX;
           } else {
             scope.widgetConfig.state().chart.height = null;
           }
@@ -231,7 +238,7 @@ explorer.components.widget.data_viz.gviz.gvizChart = function(
       let adjustWidth = function() {
         if (scope.widgetConfig.model.chart) {
           scope.widgetConfig.state().chart.width =
-              element.parent().prop('offsetWidth') - 1;
+              element.parent().prop('offsetWidth') - CHART_EXTRA_WIDTH_PX;
         }
       };
       adjustWidth();

--- a/client/components/widget/widget-directive.js
+++ b/client/components/widget/widget-directive.js
@@ -46,46 +46,7 @@ explorer.components.widget.perfkitWidget = function() {
     scope: {
       widgetConfig: '='
     },
-    templateUrl: '/static/components/widget/widget-directive.html',
-    link: function(scope, element, attributes) {
-      let basis;
-
-      let adjustColumnSize = function() {
-        let columnspan = scope.widgetConfig.model.layout.columnspan;
-        // Column size is a percent value multiply by columnspan
-        basis =
-            (100 / scope.widgetConfig.state().parent.model.container.columns) *
-            columnspan;
-        // Set minimum width multiply by columnspan
-        let minWidth = perfkitWidget.MIN_COLUMN_WIDTH * columnspan;
-        // Apply new style value
-        scope.layoutStyle = {
-          '-webkit-flex-basis': basis + '%',
-          'flex-basis': basis + '%',
-          'min-width': minWidth + 'px'
-        };
-      };
-      adjustColumnSize();
-
-      scope.$watch('widgetConfig.state().parent.model.container.columns',
-          function(oldVal, newVal) {
-            if (oldVal !== newVal &&
-                scope.widgetConfig.state().parent.model.container.columns > 0) {
-              adjustColumnSize();
-            }
-          }
-      );
-
-      // When the columnspan changes
-      scope.$watch('widgetConfig.model.layout.columnspan',
-          function(oldVal, newVal) {
-            if (oldVal !== newVal &&
-                scope.widgetConfig.model.layout.columnspan > 0) {
-              adjustColumnSize();
-            }
-          }
-      );
-    }
+    templateUrl: '/static/components/widget/widget-directive.html'
   };
 };
 let perfkitWidget = explorer.components.widget.perfkitWidget;


### PR DESCRIPTION
This prevents spurious scrollbars from appearing on charts.  Note this issue only repros on Linux/Chrome, not OSX/Chrome.

Demo is at https://27-1-dot-perfkit-explorer.googleplex.com