### PR TITLE
Suppress errors when a request contains no job id

### DIFF
--- a/client/components/widget/query/query-result-data-service.js
+++ b/client/components/widget/query/query-result-data-service.js
@@ -233,19 +233,29 @@ QueryResultDataService.prototype.fetchResults = function(widget) {
         let rows = response.data.totalRows;
         let size = response.data.totalBytesProcessed;
         let time = response.data.elapsedTime;
-        let job = response.data.jobReference.jobId;
+        let jobReference = response.data.jobReference;
 
-        widget.state().datasource.job_id = job;
+        if (goog.isDefAndNotNull(jobReference)) {
+          widget.state().datasource.job_id = jobReference.jobId;
+        }
         widget.state().datasource.row_count = rows;
         widget.state().datasource.query_size = size;
         widget.state().datasource.query_time = time;
 
         if (this.explorerService_.model.logStatistics) {
-          this.errorService_.addError(
-              ErrorTypes.INFO,
-              'Returned ' + this.filter_('number')(rows, 0) + ' records, ' +
-              'processing ' + this.filter_('number')(size/1000000, 2) + 'MB ' +
-              'in ' + this.filter_('number')(time, 2) + ' sec.');
+          let clauses = [];
+          if (goog.isDefAndNotNull(rows)) {
+            clauses.push('Returned' + this.filter_('number')(rows, 0) + ' records');
+          }
+          if (goog.isDefAndNotNull(size)) {
+            clauses.push('Processing' + this.filter_('number')(size/1000000, 2) + 'MB');
+          }
+          if (goog.isDefAndNotNull(time)) {
+            clauses.push('In ' + this.filter_('number')(time, 2) + ' sec.');
+          }
+          let msg = clauses.join(' ');
+
+          this.errorService_.addError(ErrorTypes.INFO, msg);
         }
 
         let data = response.data.results;


### PR DESCRIPTION
This has been an issue for error conditions, as well as certain cases with text/cloudsql widgets.

Demo is at https://27-1-dot-perfkit-explorer.googleplex.com