### PR TITLE
Fixes silent failure issues

### DIFF
--- a/client/components/widget/data_viz/gviz/gviz-directive.js
+++ b/client/components/widget/data_viz/gviz/gviz-directive.js
@@ -141,7 +141,7 @@ explorer.components.widget.data_viz.gviz.gvizChart = function(
           message = gvizChart.ERR_SAFE_MODE;
         }
         else if (scope.widgetConfig.queryError) {
-          message = 'query error: ' + scope.widgetConfig.queryError;
+          message = scope.widgetConfig.queryError;
         }
         else if (scope.widgetConfig.state().datasource.status ===
                  ResultsDataStatus.NODATA) {

--- a/client/components/widget/query/query-result-data-service.js
+++ b/client/components/widget/query/query-result-data-service.js
@@ -44,6 +44,8 @@ const WorkQueueService = explorer.components.util.WorkQueueService;
 const WidgetConfig = explorer.models.WidgetConfig;
 
 
+const ERR_UNEXPECTED = 'An unexpected error occurred.';
+
 /**
  * See module docstring for more information about purpose and usage.
  *
@@ -226,7 +228,11 @@ QueryResultDataService.prototype.fetchResults = function(widget) {
         isSelected);
 
     promise.then(angular.bind(this, function(response) {
-      if (response.data.error) {
+      console.log(response);
+      if (goog.isDefAndNotNull(response.data.error)) {
+        if (goog.string.isEmptySafe(response.data.error)) {
+          response.data.error = ERR_UNEXPECTED;
+        }
         this.errorService_.addError(ErrorTypes.DANGER, response.data.error);
         deferred.reject(response.data);
       } else {

--- a/client/components/widget/query/query-result-data-service.js
+++ b/client/components/widget/query/query-result-data-service.js
@@ -228,7 +228,6 @@ QueryResultDataService.prototype.fetchResults = function(widget) {
         isSelected);
 
     promise.then(angular.bind(this, function(response) {
-      console.log(response);
       if (goog.isDefAndNotNull(response.data.error)) {
         if (goog.string.isEmptySafe(response.data.error)) {
           response.data.error = ERR_UNEXPECTED;

--- a/client/components/widget/query/query-result-data-service.js
+++ b/client/components/widget/query/query-result-data-service.js
@@ -44,7 +44,8 @@ const WorkQueueService = explorer.components.util.WorkQueueService;
 const WidgetConfig = explorer.models.WidgetConfig;
 
 
-const ERR_UNEXPECTED = 'An unexpected error occurred.';
+const ERR_FETCH = ''
+const ERR_UNEXPECTED = 'The HTTP response returned no details.';
 
 /**
  * See module docstring for more information about purpose and usage.
@@ -232,6 +233,10 @@ QueryResultDataService.prototype.fetchResults = function(widget) {
         if (goog.string.isEmptySafe(response.data.error)) {
           response.data.error = ERR_UNEXPECTED;
         }
+        response.data.error = (
+          'An error occurred when fetching data from ' + widget.model.datasource.type + ': ' +
+          response.data.error
+        );
         this.errorService_.addError(ErrorTypes.DANGER, response.data.error);
         deferred.reject(response.data);
       } else {
@@ -274,7 +279,11 @@ QueryResultDataService.prototype.fetchResults = function(widget) {
     }));
     // Error handling
     promise.then(null, angular.bind(this, function(response) {
-      this.errorService_.addError(ErrorTypes.DANGER, response.error || response.statusText);
+      response.error = (
+        'An error occurred when fetching data from ' + widget.model.datasource.type + ': ' +
+        (response.error || response.statusText)
+      );
+      this.errorService_.addError(ErrorTypes.DANGER, response.error);
 
       deferred.reject(response);
     }));

--- a/client/components/widget/query/query-result-data-service_test.js
+++ b/client/components/widget/query/query-result-data-service_test.js
@@ -119,18 +119,16 @@ describe('queryResultDataService', function() {
 
   describe('fetchResults', function() {
 
-    fit('should apply a default error messsage when an empty error is returned',
+    it('should apply a default error messsage when an empty error is returned',
         function() {
           var response = null;
           var query = endpoint;
           var widget = new ChartWidgetConfig(widgetFactorySvc);
           widget.model.datasource.query = 'fakeQuery1';
 
-          var response = {
+          var mockResponse = {
             endpoint: '/data/sql',
-            data: {
-              error: ''
-            }
+            error: ''
           }
     
           var params = {
@@ -138,19 +136,16 @@ describe('queryResultDataService', function() {
               'id': widget.model.id,
               'datasource': widget.model.datasource
           };
-          httpBackend.expectPOST(query, params).respond(response);
+          httpBackend.expectPOST(query, params).respond(mockResponse);
 
           var promise = svc.fetchResults(widget);
-          promise.then(function(data) {
+          promise.catch(function(data) {
             response = data;
           });
 
           httpBackend.flush();
-          console.log(response);
           expect(response).not.toBeNull();
-          expect(response.data).not.toBeNull();
-          expect(response.data.error).not.toBeNull();
-          expect(response.data.error).toBe('An unexpected error occurred.');
+          expect(response.error).toBe('An unexpected error occurred.');
         }
     );
 

--- a/client/components/widget/query/query-result-data-service_test.js
+++ b/client/components/widget/query/query-result-data-service_test.js
@@ -119,6 +119,41 @@ describe('queryResultDataService', function() {
 
   describe('fetchResults', function() {
 
+    fit('should apply a default error messsage when an empty error is returned',
+        function() {
+          var response = null;
+          var query = endpoint;
+          var widget = new ChartWidgetConfig(widgetFactorySvc);
+          widget.model.datasource.query = 'fakeQuery1';
+
+          var response = {
+            endpoint: '/data/sql',
+            data: {
+              error: ''
+            }
+          }
+    
+          var params = {
+              'dashboard_id': null,
+              'id': widget.model.id,
+              'datasource': widget.model.datasource
+          };
+          httpBackend.expectPOST(query, params).respond(response);
+
+          var promise = svc.fetchResults(widget);
+          promise.then(function(data) {
+            response = data;
+          });
+
+          httpBackend.flush();
+          console.log(response);
+          expect(response).not.toBeNull();
+          expect(response.data).not.toBeNull();
+          expect(response.data.error).not.toBeNull();
+          expect(response.data.error).toBe('An unexpected error occurred.');
+        }
+    );
+
     it('should fetch the samples results of a query as a DataTable.',
         function() {
           var dataTable = null;


### PR DESCRIPTION
In cases where error messages aren't returning a string, Explorer is silently failing, and the widget will continue to appear in a loading state.  This fixes the issue so that "An unexpected error occurred" appears if no error text is provided.