### PR TITLE
Updated README to reflect proper usage of --project_id flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Create the BigQuery repository
 
          pushd ~/projects/PerfKitExplorer/data/samples_mart
 
-         bq load --project=MY_PROJECT_ID \
+         bq load --project_id=MY_PROJECT_ID \
            --source_format=NEWLINE_DELIMITED_JSON \
            samples_mart.results \
            ./sample_results.json \


### PR DESCRIPTION
Updated README to reflect proper usage of `--project_id` flag when
loading data. I am not entirely sure why it is only with `bq load`
that you have to use `--project_id=` yet the rest of the times `bq` uses
`--project=`