### PR TITLE
Switch to http then() method for supporting angular 1.6

### DIFF
--- a/client/components/widget/data_viz/gviz/chart-wrapper-service.js
+++ b/client/components/widget/data_viz/gviz/chart-wrapper-service.js
@@ -145,12 +145,12 @@ const ChartWrapperService = (
  */
 ChartWrapperService.prototype.loadCharts = function() {
   this.http_.get('/static/components/widget/data_viz/gviz/gviz-charts.json').
-      success(angular.bind(this, function(response) {
-        goog.array.extend(this.allCharts, response);
+      then(angular.bind(this, function(response) {
+        goog.array.extend(this.allCharts, response.data);
          this.allChartsIndex = /** @type {!Object<!ChartTypeModel>} */ (
           this.arrayUtilSvc_.getDictionary(this.allCharts, 'className'));
-      })).
-      error(angular.bind(this, function(response) {
+      }),
+      angular.bind(this, function(response) {
         while (this.allCharts.length > 0) {
           this.allCharts.pop();
         }


### PR DESCRIPTION
`http.success()` was deprecated in 1.5 and removed in 1.6.

https://code.angularjs.org/1.6.2/docs/guide/migration#migrate1.5to1.6-ng-services-$http